### PR TITLE
Change the Executor semantic.

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Cuttle.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Cuttle.scala
@@ -16,7 +16,7 @@ class Cuttle[S <: Scheduling](
     databaseConfig: DatabaseConfig = Database.configFromEnv
   ) = {
     val database = Database.connect(databaseConfig)
-    val executor = Executor[S](platforms, queries, database)
+    val executor = Executor[S](platforms, queries, database)(ordering)
     Server.listen(port = httpPort, onError = { e =>
       e.printStackTrace()
       InternalServerError("LOL")

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeseriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeseriesApp.scala
@@ -6,14 +6,46 @@ import lol.json._
 import io.circe._
 import io.circe.syntax._
 
+import continuum._
+import continuum.bound._
+
 import java.time.LocalDateTime
 import java.util.UUID
 
 trait TimeSeriesApp { self: TimeSeriesScheduler =>
 
+  import com.criteo.cuttle.JsonApi._
+
+  implicit val intervalEncoder = new Encoder[Interval[LocalDateTime]] {
+    override def apply(interval: Interval[LocalDateTime]) = {
+      val Closed(start) = interval.lower.bound
+      val Open(end) = interval.upper.bound
+      Json.obj(
+        "start" -> start.asJson,
+        "end" -> end.asJson
+      )
+    }
+  }
+
   override lazy val routes: PartialService = {
     case GET at "/api/timeseries" =>
-      Ok(s"TimeSeries: ${this.state}")
+      val (intervals, backfills) = state
+      Ok(Json.obj(
+        "jobs" -> Json.obj(
+          intervals.toSeq.map { case (job, intervals) =>
+            job.id -> Json.fromValues(intervals.map(_.asJson))
+          }.sortBy(_._1):_*
+        ),
+        "backfills" -> Json.fromValues(backfills.toSeq.sortBy(_.id).map { backfill =>
+          Json.obj(
+            "id" -> backfill.id.asJson,
+            "start" -> backfill.start.asJson,
+            "end" -> backfill.end.asJson,
+            "jobs" -> Json.fromValues(backfill.jobs.map(_.id.asJson)),
+            "priority" -> backfill.priority.asJson
+          )
+        })
+      ))
 
     case POST at url"/api/timeseries/backfill?job=$id&startDate=$start&endDate=$end&priority=$priority" =>
       val job = this.state._1.keySet.find(_.id == id).get

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeseriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeseriesScheduler.scala
@@ -154,10 +154,10 @@ case class TimeSeriesScheduler() extends Scheduler[TimeSeriesScheduling] with Ti
         stillRunning.map { case (job, context, _) => (job, context) },
         IntervalSet(Interval.lessThan(LocalDateTime.now()))
       )
-      val newRunning = stillRunning ++ toRun.map {
-        case (job, context) =>
-          (job, context, executor.run(job, context).result)
+      val newRunning = stillRunning ++ executor.runAll(toRun).map { submitted =>
+        (submitted.execution.job, submitted.execution.context, submitted.result)
       }
+
       Future.firstCompletedOf(utils.Timeout(ScalaDuration.create(1, "s")) :: newRunning.map(_._3).toList).andThen {
         case _ => go(newRunning)
       }


### PR DESCRIPTION
Now, when submitting a (job,context) while the same (job,context) is already running, no new execution will be submitted, and a pointer to the existing one will be returned. It means that you can't execute the same (job,context) concurrently several times.