### PR TITLE
Throttle execution retries.

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/App.scala
+++ b/core/src/main/scala/com/criteo/cuttle/App.scala
@@ -4,6 +4,7 @@ import lol.json._
 import lol.http._
 import JsonApi._
 
+import io.circe._
 import io.circe.syntax._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -16,6 +17,16 @@ case class App[S <: Scheduling](project: Project, workflow: Graph[S], scheduler:
 
     case GET at url"/api/executions/paused" =>
       Ok(executor.pausedExecutions.asJson)
+
+    case GET at url"/api/executions/failing" =>
+      Ok(executor.failingExecutions.map {
+        case (execution, failingJob, launchDate) =>
+          Json.obj(
+            "execution" -> execution.asJson,
+            "plannedLaunchDate" -> launchDate.asJson,
+            "previouslyFailedExecutions" -> failingJob.failedExecutions.map(_.asJson).asJson
+          )
+      }.asJson)
 
     case GET at url"/api/executions/archived" =>
       Ok(executor.archivedExecutions.asJson)

--- a/core/src/main/scala/com/criteo/cuttle/Execution.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Execution.scala
@@ -1,6 +1,7 @@
 package com.criteo.cuttle
 
-import java.time.{LocalDateTime, ZonedDateTime}
+import java.util.{Timer, TimerTask}
+import java.time.{Duration, LocalDateTime, ZoneId, ZonedDateTime}
 import java.time.format.DateTimeFormatter.{ISO_INSTANT}
 
 import scala.util.{Failure, Success}
@@ -16,11 +17,25 @@ import doobie.imports._
 
 import io.circe._
 
+trait RetryStrategy[S <: Scheduling] extends ((Job[S], S#Context, FailingJob) => Duration) {
+  def retryWindow: Duration
+}
+
+object RetryStrategy {
+  implicit def ExponentialBackoffRetryStrategy[A <: Scheduling] = new RetryStrategy[A] {
+    def apply(job: Job[A], ctx: A#Context, failingJob: FailingJob) =
+      retryWindow.multipliedBy(math.pow(2, failingJob.failedExecutions.size - 1).toLong)
+    def retryWindow =
+      Duration.ofMinutes(5)
+  }
+}
+
 sealed trait ExecutionStatus
 case object ExecutionSuccessful extends ExecutionStatus
 case object ExecutionFailed extends ExecutionStatus
 case object ExecutionRunning extends ExecutionStatus
 case object ExecutionPaused extends ExecutionStatus
+case object ExecutionThrottled extends ExecutionStatus
 
 case class ExecutionLog(
   id: String,
@@ -89,8 +104,14 @@ object ExecutionPlatform {
     platforms.find(classTag[E].runtimeClass.isInstance).map(_.asInstanceOf[E])
 }
 
+case class FailingJob(failedExecutions: List[ExecutionLog]) {
+  def isLastFailureAfter(date: LocalDateTime): Boolean =
+    failedExecutions.headOption.flatMap(_.endTime).exists(_.isAfter(date))
+}
+
 case class Executor[S <: Scheduling](platforms: Seq[ExecutionPlatform[S]], queries: Queries, xa: XA)(
-  implicit contextOrdering: Ordering[S#Context]) {
+  implicit retryStrategy: RetryStrategy[S],
+  contextOrdering: Ordering[S#Context]) {
 
   private val pausedState = {
     val byId = TMap.empty[String, Map[Execution[S], Promise[Unit]]]
@@ -98,8 +119,10 @@ case class Executor[S <: Scheduling](platforms: Seq[ExecutionPlatform[S]], queri
     byId.single ++= pausedIds.map((_, Map.empty[Execution[S], Promise[Unit]]))
     byId
   }
-
   private val runningState = TMap.empty[Execution[S], Future[Unit]]
+  private val throttledState = TMap.empty[Execution[S], (Promise[Unit], FailingJob, LocalDateTime)]
+  private val recentFailures = TMap.empty[(Job[S], S#Context), (Option[Execution[S]], FailingJob)]
+  private val timer = new Timer("com.criteo.cuttle.Executor.timer")
 
   def runningExecutions: Seq[ExecutionLog] =
     runningState.single.snapshot.keys.toSeq.map { execution =>
@@ -111,21 +134,30 @@ case class Executor[S <: Scheduling](platforms: Seq[ExecutionPlatform[S]], queri
       execution.toExecutionLog(ExecutionPaused)
     }
 
+  def failingExecutions: Seq[(ExecutionLog, FailingJob, LocalDateTime)] =
+    throttledState.single.toSeq.map {
+      case (execution, (_, failingJob, launchDate)) =>
+        (execution.toExecutionLog(ExecutionThrottled), failingJob, launchDate)
+    }
+
   def pausedJobs: Seq[String] =
     pausedState.single.keys.toSeq
 
   def archivedExecutions: Seq[ExecutionLog] =
     queries.getExecutionLog.transact(xa).unsafePerformIO
 
-  def cancelExecution(executionId: String): Unit =
-    (runningState.single.keys ++ pausedState.single.values.flatMap(_.keys))
-      .find(_.id == executionId)
-      .foreach(_.cancel())
+  def cancelExecution(executionId: String): Unit = {
+    val toCancel = atomic { implicit tx =>
+      (runningState.keys ++ pausedState.values.flatMap(_.keys) ++ throttledState.keys).
+        find(_.id == executionId)
+    }
+    toCancel.foreach(_.cancel())
+  }
 
   def unpauseJob(job: Job[S]): Unit = {
     val executionsToResume = atomic { implicit tx =>
       Txn.setExternalDecider(new ExternalDecider {
-        def shouldCommit(implicit txn: InTxnEnd): Boolean = {
+        def shouldCommit(implicit tx: InTxnEnd): Boolean = {
           queries.unpauseJob(job).transact(xa).unsafePerformIO
           true
         }
@@ -158,7 +190,7 @@ case class Executor[S <: Scheduling](platforms: Seq[ExecutionPlatform[S]], queri
         }
       })
       pausedState += (job.id -> Map.empty)
-      runningState.filterKeys(_.job == job).keys
+      runningState.filterKeys(_.job == job).keys ++ throttledState.filterKeys(_.job == job).keys
     }
     executionsToCancel.toList.sortBy(_.context).reverse.foreach { execution =>
       execution.streams.debug(s"Job ${job.id} has been paused.")
@@ -174,8 +206,22 @@ case class Executor[S <: Scheduling](platforms: Seq[ExecutionPlatform[S]], queri
         .andThen {
           case Success(()) =>
             execution.streams.debug(s"Execution successful.")
+            recentFailures.single -= (execution.job -> execution.context)
           case Failure(e) =>
             execution.streams.debug(s"Execution failed with message: ${e.getMessage}.")
+            atomic {
+              implicit tx =>
+                recentFailures.retain {
+                  case (_, (retryExecution, failingJob)) =>
+                    retryExecution.isDefined || failingJob.isLastFailureAfter(
+                      LocalDateTime.now.minus(retryStrategy.retryWindow))
+                }
+                val failureKey = (execution.job, execution.context)
+                val failingJob = recentFailures.get(failureKey).map(_._2).getOrElse(FailingJob(Nil))
+                recentFailures += (failureKey -> (None -> failingJob.copy(failedExecutions = execution
+                  .toExecutionLog(ExecutionFailed)
+                  .copy(endTime = Some(LocalDateTime.now)) :: failingJob.failedExecutions)))
+            }
         }
         .andThen {
           case result =>
@@ -196,55 +242,122 @@ case class Executor[S <: Scheduling](platforms: Seq[ExecutionPlatform[S]], queri
   def runAll(all: Seq[(Job[S], S#Context)]): Seq[SubmittedExecution[S]] = all.sortBy(_._2).map((run _).tupled)
 
   def run(job: Job[S], context: S#Context): SubmittedExecution[S] = {
-    val existingOrNew: Either[SubmittedExecution[S], (Execution[S], Promise[Unit], Boolean)] = atomic { implicit tx =>
-      val maybeAlreadyRunning: Option[(Execution[S], Future[Unit])] =
-        runningState.find { case (e, f) => e.job == job && e.context == context }
+    sealed trait NewExecution
+    case object ToRunNow extends NewExecution
+    case object Paused extends NewExecution
+    case class Throttled(launchDate: LocalDateTime) extends NewExecution
 
-      lazy val maybePaused: Option[(Execution[S], Future[Unit])] =
-        pausedState.get(job.id).getOrElse(Map.empty).find { case (e, p) => e.job == job && e.context == context }.map {
-          case (e, p) => (e, p.future)
-        }
+    val existingOrNew: Either[SubmittedExecution[S], (Execution[S], Promise[Unit], NewExecution)] = atomic {
+      implicit tx =>
+        val maybeAlreadyRunning: Option[(Execution[S], Future[Unit])] =
+          runningState.find { case (e, _) => e.job == job && e.context == context }
 
-      maybeAlreadyRunning.orElse(maybePaused).map((SubmittedExecution.apply[S] _).tupled).toLeft {
-        val nextExecutionId = utils.randomUUID
-        val execution = Execution(
-          id = nextExecutionId,
-          job = job,
-          context = context,
-          startTime = LocalDateTime.now(),
-          streams = new ExecutionStreams {
-            def println(str: CharSequence) = System.out.println(s"@$nextExecutionId - $str")
-          },
-          platforms = platforms
-        )
-        val promise = Promise[Unit]
+        lazy val maybePaused: Option[(Execution[S], Future[Unit])] =
+          pausedState
+            .get(job.id)
+            .getOrElse(Map.empty)
+            .find { case (e, _) => e.job == job && e.context == context }
+            .map {
+              case (e, p) => (e, p.future)
+            }
 
-        if (pausedState.contains(job.id)) {
-          val pausedExecutions = pausedState(job.id) + (execution -> promise)
-          pausedState += (job.id -> pausedExecutions)
-          (execution, promise, false)
-        } else {
-          runningState += (execution -> promise.future)
-          (execution, promise, true)
-        }
-      }
+        lazy val maybeThrottled: Option[(Execution[S], Future[Unit])] =
+          throttledState.find { case (e, _) => e.job == job && e.context == context }.map {
+            case (e, (p, _, _)) => (e, p.future)
+          }
+
+        maybeAlreadyRunning
+          .orElse(maybePaused)
+          .orElse(maybeThrottled)
+          .map((SubmittedExecution.apply[S] _).tupled)
+          .toLeft {
+            val nextExecutionId = utils.randomUUID
+            val execution = Execution(
+              id = nextExecutionId,
+              job = job,
+              context = context,
+              startTime = LocalDateTime.now(),
+              streams = new ExecutionStreams {
+                def println(str: CharSequence) = System.out.println(s"@$nextExecutionId - $str")
+              },
+              platforms = platforms
+            )
+            val promise = Promise[Unit]
+
+            if (pausedState.contains(job.id)) {
+              val pausedExecutions = pausedState(job.id) + (execution -> promise)
+              pausedState += (job.id -> pausedExecutions)
+              (execution, promise, Paused)
+            } else if (recentFailures.contains(job -> context)) {
+              val (_, failingJob) = recentFailures(job -> context)
+              recentFailures += ((job -> context) -> (Some(execution) -> failingJob))
+              val throttleFor = retryStrategy(job, context, recentFailures(job -> context)._2)
+              val launchDate = failingJob.failedExecutions.head.endTime.get.plus(throttleFor)
+              throttledState += (execution -> ((promise, failingJob, launchDate)))
+              (execution, promise, Throttled(launchDate))
+            } else {
+              runningState += (execution -> promise.future)
+              (execution, promise, ToRunNow)
+            }
+          }
     }
 
     existingOrNew.fold(
       identity, {
-        case (execution, promise, doRunNow) =>
-          execution.streams.debug(s"Execution ${execution.id}, for ${execution.context}")
-          if (doRunNow) {
-            unsafeDoRun(execution, promise)
-          } else {
-            execution.streams.debug(s"Job ${execution.job.id}, is paused.")
-            execution.onCancelled { () =>
-              atomic { implicit tx =>
-                val pausedExecutions = pausedState.get(job.id).getOrElse(Map.empty).filterKeys(_ == execution)
-                pausedState += (job.id -> pausedExecutions)
+        case (execution, promise, whatToDo) =>
+          execution.streams.debug(s"Execution ${execution.id}, will run for ${execution.context}")
+          whatToDo match {
+            case ToRunNow =>
+              unsafeDoRun(execution, promise)
+            case Paused =>
+              execution.streams.debug(s"Delayed because job ${execution.job.id} is paused.")
+              execution.onCancelled { () =>
+                val cancelNow = atomic { implicit tx =>
+                  val isStillPaused = pausedState.get(job.id).getOrElse(Map.empty).contains(execution)
+                  if (isStillPaused) {
+                    val pausedExecutions = pausedState.get(job.id).getOrElse(Map.empty).filterKeys(_ == execution)
+                    pausedState += (job.id -> pausedExecutions)
+                    true
+                  } else {
+                    false
+                  }
+                }
+                if (cancelNow) promise.tryFailure(ExecutionCancelled)
               }
-              promise.tryFailure(ExecutionCancelled)
-            }
+            case Throttled(launchDate) =>
+              execution.streams.debug(s"Throttled because previous execution failed. Delayed until ${launchDate}.")
+              val timerTask = new TimerTask {
+                def run = {
+                  val runNow = atomic { implicit tx =>
+                    if (throttledState.contains(execution)) {
+                      throttledState -= execution
+                      true
+                    } else {
+                      false
+                    }
+                  }
+                  if (runNow) unsafeDoRun(execution, promise)
+                }
+              }
+              timer.schedule(timerTask, java.util.Date.from(launchDate.atZone(ZoneId.systemDefault()).toInstant))
+              execution.onCancelled { () =>
+                val cancelNow = atomic { implicit tx =>
+                  val failureKey = (execution.job -> execution.context)
+                  recentFailures.get(failureKey).foreach {
+                    case (_, failingJob) =>
+                      recentFailures += (failureKey -> (None -> failingJob))
+                  }
+                  val isStillDelayed = throttledState.contains(execution)
+                  if (isStillDelayed) {
+                    throttledState -= execution
+                    true
+                  } else {
+                    false
+                  }
+                }
+                if (cancelNow) promise.tryFailure(ExecutionCancelled)
+              }
+
           }
           SubmittedExecution(execution, promise.future)
       }

--- a/core/src/main/scala/com/criteo/cuttle/JsonApi.scala
+++ b/core/src/main/scala/com/criteo/cuttle/JsonApi.scala
@@ -32,6 +32,7 @@ object JsonApi {
           case ExecutionFailed => "failed"
           case ExecutionRunning => "running"
           case ExecutionPaused => "paused"
+          case ExecutionThrottled => "throttled"
         }).asJson
       )
   }

--- a/examples/src/main/scala/com/criteo/cuttle/examples/HelloWorld.scala
+++ b/examples/src/main/scala/com/criteo/cuttle/examples/HelloWorld.scala
@@ -29,6 +29,7 @@ object HelloWorld {
           sh"""
         echo "${e.context} -> Hello";
         sleep 3
+        ${if (e.context.start.isBefore(date"2017-05-10T01:00Z")) "oops" else ""}
       """.exec()
       }
 


### PR DESCRIPTION
We define a retry as an execution (job, context) that fail and is followed
by a new attempt to execute it. When it happens, instead of just executing
again right away, we throttle it based on a RetryStrategy function. The default
strategy implements an exponential backoff retry delay.

It also allow us to define a list of failing executions that will appear in the
UI, and we define a new API endpoint for it.