### PR TITLE
Simplify the Scala API, and fix the HelloWorld example.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val examples =
       fork in Test := true,
       connectInput in Test := true
     )
-    .dependsOn(cuttle, timeseries)
+    .dependsOn(cuttle, timeseries, localdb)
 
 lazy val root =
   (project in file("."))

--- a/core/src/main/scala/com/criteo/cuttle/Graph.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Graph.scala
@@ -45,10 +45,10 @@ sealed trait Graph[S <: Scheduling] {
 case class Tag(name: String, description: Option[String] = None, color: Option[String] = None)
 
 case class Job[S <: Scheduling](id: String,
+                                scheduling: S,
                                 name: Option[String] = None,
                                 description: Option[String] = None,
-                                tags: Set[Tag] = Set.empty[Tag],
-                                scheduling: S)(val effect: Execution[S] => Future[Unit])
+                                tags: Set[Tag] = Set.empty[Tag])(val effect: Execution[S] => Future[Unit])
     extends Graph[S] {
   val vertices = Set(this)
   val edges = Set.empty[Dependency]

--- a/core/src/test/scala/com/criteo/cuttle/CuttleSpec.scala
+++ b/core/src/test/scala/com/criteo/cuttle/CuttleSpec.scala
@@ -23,7 +23,7 @@ case class TestScheduling(config: Unit = ()) extends Scheduling {
 class LangoustinePPSpec extends FunSuite {
   test("Graph building") {
     val jobs =
-      (0 to 3).map(i => Job(i.toString, None, None, Set(), TestScheduling())(_ => Future.successful(())))
+      (0 to 3).map(i => Job(i.toString, TestScheduling())(_ => Future.successful(())))
     val graph = (jobs(1) and jobs(2)) dependsOn jobs(0) dependsOn jobs(3)
     assert(graph.vertices.size == 4)
     assert(graph.edges.size == 3)

--- a/examples/src/main/scala/com/criteo/cuttle/examples/HelloWorld.scala
+++ b/examples/src/main/scala/com/criteo/cuttle/examples/HelloWorld.scala
@@ -3,102 +3,60 @@ package com.criteo.cuttle.examples
 import com.criteo.cuttle._
 import timeseries._
 
+import java.io._
+import java.time._
+import java.time.temporal._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
 object HelloWorld {
 
   def main(args: Array[String]): Unit = {
-    val start = date"2017-05-10T00:00Z"
-    val tagPolite = Tag("Polite", Some("Jobs that greet you politely"), Some("#27ae60"))
-    val tagPure = Tag("Pure", Some("Jobs with no side effects"), Some("#3498db"))
-    val tagLRCheck = Tag("LRCheck", Some("Jobs that check last runs"), Some("#95a5a6"))
-    val tagBigFilter = Tag(name = "BigFilter", color = Some("#e74c3c"))
-    val tagCharacter = Tag(name = "Character", color = Some("#8e44ad"))
-    val tagItalian = Tag(name = "Italian", color = Some("#e67e22"))
-    val tagLiatiel = Tag(name = "Liatel", color = Some("#f1c40f"))
+    // Yesterday at 00:00 UTC
+    val start = LocalDateTime.now.minusDays(1).truncatedTo(ChronoUnit.DAYS)
 
-    val hello1 = Job("1", Some("Hello 1"), Some("The Hello Job 1"), Set(tagPolite, tagLRCheck), hourly(start)) {
-      implicit e =>
+    val hello1 =
+      Job("hello1", hourly(start)) { implicit e =>
         sh"""
-        echo "${e.context} -> Hello";
-        sleep 3
-      """.exec()
-    }
-
-    val hello2 =
-      Job("2", Some("Hello 2"), Some("The Hello Job 2"), Set(tagPolite, tagLRCheck, tagPure), hourly(start)) {
-        implicit e =>
-          sh"""
-        echo "${e.context} -> Hello";
-        sleep 3
-      """.exec()
+          echo "Hello 1"
+          sleep 1
+        """.exec()
       }
 
-    val hello3 = Job("3", Some("Hello 3"), Some("The Hello Job 3"), Set(tagPolite), hourly(start)) { implicit e =>
+    val hello2 =
+      Job("hello2", hourly(start)) { implicit e =>
+        sh"""
+          echo "Hello 2"
+          sleep 2
+        """.exec()
+      }
+
+    val hello3 =
+      Job("hello3", hourly(start)) { implicit e =>
+        sh"""
+          echo "Hello 3"
+          sleep 3
+        """.exec().map { _ =>
+          // Artificially fail for the first hour of the computation period
+          // if /tmp/hello3_success does not exist
+          if (e.context.start == start && !new File("/tmp/hello3_success").exists) {
+            e.streams.error("Oops, please create the /tmp/hello3_success file to make this execution pass...")
+            sys.error("Oops!!!")
+          } else {
+            e.streams.info("Success file found!")
+          }
+        }
+      }
+
+    val world = Job("world", daily("UTC", start)) { implicit e =>
       sh"""
-        echo "${e.context} -> Hello";
-        sleep 3
-      """.exec()
-    }
-
-    val hello4 = Job("4", Some("Hello 4"), Some("The Hello Job 4"), Set(tagPolite), hourly(start)) { implicit e =>
-      sh"""
-        echo "${e.context} -> Hello";
-        sleep 3
-      """.exec()
-    }
-
-    val world = Job("world", Some("World"), Some("The World Job"), Set(tagBigFilter), daily("UTC", start)) {
-      implicit e =>
-        sh"""
-        echo "${e.context} -> World";
-        sleep 1
-      """.exec()
-    }
-
-    val coma = Job("comaJob", Some(","), Some("The World Job"), Set(tagBigFilter, tagPolite), daily("UTC", start)) {
-      implicit e =>
-        sh"""
-        echo "${e.context} -> World";
-        sleep 1
-      """.exec()
-    }
-
-    val excl = Job("exclJob", Some("!"), Some("The Excl Job"), Set(tagBigFilter, tagPure), daily("UTC", start)) {
-      implicit e =>
-        sh"""
-        echo "${e.context} -> World";
-        sleep 1
-      """.exec()
-    }
-
-    val JB = Job("jbJob", Some("Jay Bee"), Some("The Jay Bee Job"), Set(tagItalian, tagPolite), daily("UTC", start)) {
-      implicit e =>
-        sh"""
-        echo "${e.context} -> World";
-        sleep 1
-      """.exec()
-    }
-
-    val giulio = Job("italianJob",
-                     Some("Giulio"),
-                     Some("Giulio's Job"),
-                     Set(tagCharacter, tagPolite, tagLRCheck),
-                     daily("UTC", start)) { implicit e =>
-      sh"""
-        echo "${e.context} -> World";
-        sleep 1
-      """.exec()
-    }
-
-    val notFound = Job("notFound", Some("Not Foond"), Some("NF"), Set(tagLiatiel, tagItalian), daily("UTC", start)) {
-      implicit e =>
-        sh"""
-        echo "${e.context} -> World";
+        echo "World"
         sleep 1
       """.exec()
     }
 
     Cuttle("Hello World") {
-      (((JB and (notFound dependsOn giulio)) dependsOn coma) and excl) dependsOn (world dependsOn (hello1 and hello2 and hello3 and hello4))
+      world dependsOn (hello1 and hello2 and hello3)
     }.run()
   }
 

--- a/examples/src/test/scala/com/criteo/cuttle/examples/TestExample.scala
+++ b/examples/src/test/scala/com/criteo/cuttle/examples/TestExample.scala
@@ -1,24 +1,52 @@
 package com.criteo.cuttle.examples
 
+import java.io._
+
 object TestExample {
 
   def main(args: Array[String]): Unit = {
     val example = args.headOption.getOrElse(sys.error("Please specify the example to run as argument"))
-    val forked = new ProcessBuilder("java",
-                                    "-cp",
-                                    System.getProperty("java.class.path"),
-                                    s"com.criteo.cuttle.examples.$example").inheritIO.start()
 
-    new Thread() {
-      override def run: Unit = {
-        println(s"-- example `$example` started, press [Ctrl+D] to quit")
-        while (System.in.read != -1) ()
-        forked.destroy()
+    println("-- Starting a local database")
+
+    val localdb =
+      new ProcessBuilder("java", "-cp", System.getProperty("java.class.path"), "com.criteo.cuttle.localdb.LocalDB")
+        .start()
+
+    val in = new BufferedReader(new InputStreamReader(localdb.getInputStream))
+    var line = ""
+
+    while ({ line = in.readLine; line != null }) {
+      println(line)
+      if (line == "started!") {
+
+        val exampleJVM = new ProcessBuilder("java",
+                                            "-cp",
+                                            System.getProperty("java.class.path"),
+                                            s"com.criteo.cuttle.examples.$example")
+
+        exampleJVM.environment.put("MYSQL_HOST", "localhost")
+        exampleJVM.environment.put("MYSQL_PORT", "3388")
+        exampleJVM.environment.put("MYSQL_DATABASE", "cuttle_dev")
+        exampleJVM.environment.put("MYSQL_USER", "root")
+        exampleJVM.environment.put("MYSQL_PASSWORD", "")
+
+        val forked = exampleJVM.inheritIO.start()
+
+        new Thread() {
+          override def run: Unit = {
+            println(s"-- example `$example` started, press [Ctrl+D] to quit")
+            while (System.in.read != -1) ()
+            forked.destroy()
+          }
+        }.start()
+
+        forked.waitFor
+        localdb.destroy()
+        System.exit(0)
       }
-    }.start()
+    }
 
-    forked.waitFor
-    System.exit(0)
   }
 
 }

--- a/localdb/src/main/scala/com/criteo/cuttle/localdb/LocalDB.scala
+++ b/localdb/src/main/scala/com/criteo/cuttle/localdb/LocalDB.scala
@@ -11,6 +11,7 @@ object LocalDB {
       MysqldConfig.aMysqldConfig(v5_7_latest).withCharset(UTF8).withPort(3388).build()
     }
     val mysqld = EmbeddedMysql.anEmbeddedMysql(config).addSchema("cuttle_dev").start()
+    println("started!")
     println("if needed you can connect to this running db using:")
     println("> mysql -u root -h 127.0.0.1 -P 3388 cuttle_dev")
     println("press [Ctrl+D] to stop...")

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeseriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeseriesScheduler.scala
@@ -81,11 +81,8 @@ case class TimeSeriesScheduler() extends Scheduler[TimeSeriesScheduling] with Ti
   import TimeSeriesUtils._
 
   private val timer =
-    Job("timer",
-        None,
-        None,
-        Set(),
-        TimeSeriesScheduling(Continuous, LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC)))(_ => sys.error("panic!"))
+    Job("timer", TimeSeriesScheduling(Continuous, LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC)))(_ =>
+      sys.error("panic!"))
 
   private val _state = Ref(Map.empty[TimeSeriesJob, IntervalSet[LocalDateTime]])
   private val _backfills = TSet.empty[Backfill]

--- a/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSpec.scala
+++ b/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSpec.scala
@@ -13,7 +13,7 @@ import continuum.{Interval, IntervalSet}
 
 class TimeSeriesSpec extends FunSuite {
   val scheduling = hourly(LocalDateTime.of(2017, 3, 25, 2, 0))
-  val job = (0 to 10).map(i => Job(i.toString, None, None, Set(), scheduling)(_ => Future.successful(())))
+  val job = (0 to 10).map(i => Job(i.toString, scheduling)(_ => Future.successful(())))
   val scheduler = TimeSeriesScheduler()
 
   import TimeSeriesUtils.dateTimeOrdering


### PR DESCRIPTION
Make the HelloWorld example simple again. Introduce a failure case
to demonstrate failing jobs. Fix the `example' command to automatically
start a local database.