### PR TITLE
Move MySQL storage and querying logic for contexts to the scheduler

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/App.scala
+++ b/core/src/main/scala/com/criteo/cuttle/App.scala
@@ -29,17 +29,19 @@ case class App[S <: Scheduling](project: Project, workflow: Graph[S], scheduler:
   val api: PartialService = {
 
     case request @ GET at url"/api/statistics" =>
-      def getStats() = (executor.runningExecutions.size, executor.pausedExecutions.size, executor.failingExecutions.size)
-      def asJson(stats: (Int,Int,Int)) = stats match { case (running, paused, failing) =>
-        Json.obj(
-          "running" -> running.asJson,
-          "paused" -> paused.asJson,
-          "failing" -> failing.asJson
-        )
+      def getStats() =
+        (executor.runningExecutions.size, executor.pausedExecutions.size, executor.failingExecutions.size)
+      def asJson(stats: (Int, Int, Int)) = stats match {
+        case (running, paused, failing) =>
+          Json.obj(
+            "running" -> running.asJson,
+            "paused" -> paused.asJson,
+            "failing" -> failing.asJson
+          )
       }
       request.queryString match {
         case Some("stream") =>
-          sse[(Int,Int,Int)](getStats, asJson)
+          sse[(Int, Int, Int)](getStats, asJson)
         case _ =>
           Ok(asJson(getStats()))
       }
@@ -66,7 +68,7 @@ case class App[S <: Scheduling](project: Project, workflow: Graph[S], scheduler:
       }.asJson)
 
     case GET at url"/api/executions/archived" =>
-      Ok(executor.archivedExecutions.asJson)
+      Ok(executor.archivedExecutions(scheduler.allContexts).asJson)
 
     case POST at url"/api/executions/$id/cancel" =>
       executor.cancelExecution(id)

--- a/core/src/main/scala/com/criteo/cuttle/Scheduling.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Scheduling.scala
@@ -2,14 +2,17 @@ package com.criteo.cuttle
 
 import lol.http.PartialService
 import io.circe.Json
+import doobie.imports._
 
 trait Scheduler[S <: Scheduling] {
   def run(graph: Graph[S], executor: Executor[S], xa: XA): Unit
   def routes: PartialService = PartialFunction.empty
+  val allContexts: Fragment
 }
 
 trait SchedulingContext {
   def toJson: Json
+  def log: ConnectionIO[String]
 }
 
 trait Scheduling {

--- a/core/src/test/scala/com/criteo/cuttle/CuttleSpec.scala
+++ b/core/src/test/scala/com/criteo/cuttle/CuttleSpec.scala
@@ -6,12 +6,17 @@ import org.scalatest.{FunSuite}
 
 import io.circe.Json
 
+import doobie.imports._
+
+import cats.Applicative
+
 case class TestDependencyDescriptor()
 object TestDependencyDescriptor {
   implicit val defDepDescr = TestDependencyDescriptor()
 }
 case class TestContext() extends SchedulingContext {
   val toJson = Json.Null
+  val log = Applicative[ConnectionIO].pure("id")
 }
 
 case class TestScheduling(config: Unit = ()) extends Scheduling {


### PR DESCRIPTION
The `executions` table now contains a `context_id` column instead of a
JSON representation of contexts. The scheduler provides an SQL query to
translate these ids into JSON. It is also possible to provide a custom
SQL query to get execution logs for only a subset of all contexts.