### PR TITLE
[actions] remove array destructuring with flow type checking

### DIFF
--- a/core/src/main/javascript/actions.js
+++ b/core/src/main/javascript/actions.js
@@ -46,7 +46,7 @@ export const loadAppData = () => (dispatch: Dispatch) => {
     fetch("/api/workflow_definition")
   ]).then(responses => {
     Promise.all(responses.map(r => r.json())).then(
-      ([project: Project, workflow: Workflow]) =>
+      ([project, workflow]) =>
         dispatch(
           ({
             type: "LOAD_APP_DATA",


### PR DESCRIPTION
The correct syntax is:
  `([project, workflow]: [Project, Workflow]) =>`
Which fails at type checking, because flow cannot guess JSONs structure
So let’s just remove this, side note, for objects the notation is:
  `({ foo, bar = 2 }: { foo: number, bar?: number }) =>`