### PR TITLE
Streams storage.

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Database.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Database.scala
@@ -76,7 +76,7 @@ private[cuttle] object Database {
 
       CREATE TABLE executions_streams (
         id          CHAR(36) NOT NULL,
-        streams     TEXT
+        streams     MEDIUMTEXT
       ) ENGINE = INNODB;
     """
   )

--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -335,7 +335,13 @@ class Executor[S <: Scheduling] private[cuttle] (val platforms: Seq[ExecutionPla
         }
         .andThen {
           case result =>
-            ExecutionStreams.archive(execution.id, queries, xa)
+            try {
+              ExecutionStreams.archive(execution.id, queries, xa)
+            }
+            catch {
+              case e: Throwable =>
+                e.printStackTrace()
+            }
             atomic { implicit tx =>
               runningState -= execution
             }


### PR DESCRIPTION
Change MySQL column type (allows up to 16MB), and handle the error
properly. If we can't store the stream, just continue anyway.