### PR TITLE
Fix ordering

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -112,7 +112,7 @@ case class Execution[S <: Scheduling](
 
 object Execution {
   private[cuttle] implicit val ordering: Ordering[Execution[_]] =
-    Ordering.by(e => (e.context: SchedulingContext, e.job.id))
+    Ordering.by(e => (e.context: SchedulingContext, e.job.id, e.id))
 }
 
 trait ExecutionPlatform {
@@ -438,7 +438,8 @@ class Executor[S <: Scheduling] private[cuttle] (
                 } else if (recentFailures.contains(job -> context)) {
                   val (_, failingJob) = recentFailures(job -> context)
                   recentFailures += ((job -> context) -> (Some(execution) -> failingJob))
-                  val throttleFor = retryStrategy(job, context, recentFailures(job -> context)._2.failedExecutions.map(_.id))
+                  val throttleFor =
+                    retryStrategy(job, context, recentFailures(job -> context)._2.failedExecutions.map(_.id))
                   val launchDate = failingJob.failedExecutions.head.endTime.get.plus(throttleFor)
                   throttledState += (execution -> ((promise, failingJob.copy(nextRetry = Some(launchDate)))))
                   (job, execution, promise, Throttled(launchDate))

--- a/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSpec.scala
+++ b/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSpec.scala
@@ -15,8 +15,6 @@ class TimeSeriesSpec extends FunSuite {
   val job = (0 to 10).map(i => Job(i.toString, scheduling)(_ => Future.successful(())))
   val scheduler = TimeSeriesScheduler()
 
-  import TimeSeriesUtils.dateTimeOrdering
-
   test("split on hours") {
     val result =
       scheduler


### PR DESCRIPTION
2 executions cannot have the same ordering, even if it is the same job and the same context ordering.