### PR TITLE
TimeSeries: add checks before creating a new backfill

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -438,7 +438,8 @@ class Executor[S <: Scheduling] private[cuttle] (
                 } else if (recentFailures.contains(job -> context)) {
                   val (_, failingJob) = recentFailures(job -> context)
                   recentFailures += ((job -> context) -> (Some(execution) -> failingJob))
-                  val throttleFor = retryStrategy(job, context, recentFailures(job -> context)._2.failedExecutions.map(_.id))
+                  val throttleFor =
+                    retryStrategy(job, context, recentFailures(job -> context)._2.failedExecutions.map(_.id))
                   val launchDate = failingJob.failedExecutions.head.endTime.get.plus(throttleFor)
                   throttledState += (execution -> ((promise, failingJob.copy(nextRetry = Some(launchDate)))))
                   (job, execution, promise, Throttled(launchDate))

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -94,16 +94,35 @@ case class TimeSeriesScheduler() extends Scheduler[TimeSeries] with TimeSeriesAp
     (_state(), _running(), _backfills.snapshot)
   }
 
-  private[timeseries] def backfillJob(id: String, jobs: Set[TimeSeriesJob], start: Instant, end: Instant, priority: Int) =
+  private[timeseries] def backfillJob(id: String,
+                                      jobs: Set[TimeSeriesJob],
+                                      start: Instant,
+                                      end: Instant,
+                                      priority: Int) =
     atomic { implicit txn =>
       val newBackfill = Backfill(id, start, end, jobs, priority)
-      _backfills += newBackfill
-      _state() = _state() ++ jobs.map((job: TimeSeriesJob) =>
-        job -> (_state().apply(job) - Interval.closedOpen(start, end)))
+      val newBackfillDomain = backfillDomain(newBackfill)
+      if (jobs.exists(job => newBackfill.start.isBefore(job.scheduling.start))) {
+        Left("cannot before a job's start date")
+      } else if (_backfills.exists(backfill => and(backfillDomain(backfill), newBackfillDomain) != zero[StateD])) {
+        Left("intersects with another backfill")
+      } else if (newBackfillDomain.defined.exists {
+                   case (job, is) =>
+                     is.exists(interval =>
+                       IntervalSet(splitInterval(job, interval, true).map(_.toInterval).toSeq: _*) != IntervalSet(
+                         interval))
+                 }) {
+        Left("cannot backfill partial periods")
+      } else {
+        _backfills += newBackfill
+        _state() = _state() ++ jobs.map((job: TimeSeriesJob) =>
+          job -> (_state().apply(job) - Interval.closedOpen(start, end)))
+        Right(id)
+      }
     }
 
   private def backfillDomain(backfill: Backfill) =
-    backfill.jobs.map(job => job -> IntervalSet(Interval.closedOpen(backfill.start, backfill.end))).toMap
+    StateD(backfill.jobs.map(job => job -> IntervalSet(Interval.closedOpen(backfill.start, backfill.end))).toMap)
 
   def start(workflow: Workflow[TimeSeries], executor: Executor[TimeSeries], xa: XA): Unit = {
     Database.doSchemaUpdates.transact(xa).unsafePerformIO
@@ -144,7 +163,7 @@ case class TimeSeriesScheduler() extends Scheduler[TimeSeries] with TimeSeriesAp
       val (stateSnapshot, backfillSnapshot, toRun) = atomic { implicit txn =>
         addRuns(completed)
         _backfills.retain { bf =>
-          without(StateD(backfillDomain(bf)), StateD(_state())) =!= zero[StateD]
+          without(backfillDomain(bf), StateD(_state())) =!= zero[StateD]
         }
         val _toRun = next(
           workflow,
@@ -242,23 +261,32 @@ case class TimeSeriesScheduler() extends Scheduler[TimeSeries] with TimeSeriesAp
         .toMap
     }
 
-    val _dependencies =
+    val dependencies =
       (for {
         (child, parent, TimeSeriesDependency(offset)) <- workflow.edges.toList
         is = state(parent)
-      } yield StateD(Map(child -> is.map(itvl => itvl.map(_.plus(offset)))), IntervalSet(Interval.full)))
+      } yield
+        StateD(Map(child -> is.map(itvl => itvl.map(_.plus(offset)))), IntervalSet(Interval.full))).reduce(and(_, _))
 
-    val dependencies = _dependencies.reduce(and(_, _))
+    val runningDependencies = // only needed when backfilling
+      (for {
+        (child, parent, TimeSeriesDependency(offset)) <- workflow.edges.toList
+        is = runningIntervals.get(child)
+      } yield StateD(Map(parent -> is.map(itvl => itvl.map(_.minus(offset)))), IntervalSet.empty)).reduce(or(_, _))
 
     val jobDomain = StateD(
       workflow.vertices.map(job => job -> IntervalSet(Interval.atLeast(job.scheduling.start))).toMap)
 
-    val ready = Seq(complement(runningIntervals), complement(StateD(state)), jobDomain, dependencies)
+    val ready = Seq(complement(runningIntervals),
+                    complement(StateD(state)),
+                    jobDomain,
+                    dependencies,
+                    complement(runningDependencies))
       .reduce(and(_, _))
 
     val toBackfill: Map[Backfill, StateD] =
       backfills.map { backfill =>
-        backfill -> and(ready, StateD(backfillDomain(backfill)))
+        backfill -> and(ready, backfillDomain(backfill))
       }.toMap
 
     val toRunNormally = without(ready, toBackfill.values.fold(zero[StateD])(or(_, _)))


### PR DESCRIPTION
- no intersecting backfills
- no backfills before a job's startDate
- no backfilling partial periods

bonus: the scheduler won't run jobs whose dependants are running (this
is possible because of backfills)