### PR TITLE
[backfills] Creation error client display

### DIFF
--- a/core/src/main/javascript/app/pages/BackfillCreate.js
+++ b/core/src/main/javascript/app/pages/BackfillCreate.js
@@ -83,16 +83,20 @@ class BackfillCreate extends React.Component<any, Props, void> {
       `/api/timeseries/backfill?name=${name}&jobs=${jobs.join(",")}&priority=${priority}&` +
         `startDate=${start.toISOString()}&endDate=${end.toISOString()}`,
       { method: "POST" }
-    ).then(
-      (response: Response) => {
-        if (!response.ok)
-          throw new SubmissionError({ _error: response.statusText });
+    )
+      .then((response: Response) => {
+        if (!response.ok) return response.text();
         this.props.back();
-      },
-      error => {
-        throw new SubmissionError({ _error: error.message });
-      }
-    );
+        return "";
+      })
+      .then((text: string) => {
+        if (text !== undefined && text.length > 0)
+          throw new SubmissionError({ _error: text });
+      })
+      .catch((error: SubmissionError | any) => {
+        if (error instanceof SubmissionError) throw error;
+        throw new SubmissionError({ _error: error });
+      });
   }
 
   render() {

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -277,11 +277,9 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
       val jobs = this.state._1.keySet.filter((job: TimeSeriesJob) => jobIds.contains(job.id))
       val startDate = Instant.parse(start)
       val endDate = Instant.parse(end)
-      val backfillId = UUID.randomUUID().toString
-      backfillJob(backfillId, name, description, jobs, startDate, endDate, priority.toInt, xa)
-      Ok(
-        Json.obj(
-          "id" -> backfillId.asJson
-        ))
+      backfillJob(name, description, jobs, startDate, endDate, priority.toInt, xa) match {
+        case Right(id)   => Ok(Json.obj("id" -> id.asJson))
+        case Left(error) => BadRequest(error)
+      }
   }
 }


### PR DESCRIPTION
Currently backfill creation failures are ignored client side.
This commit fixes this by preventing submit and displaying server error to user.