### PR TITLE
TimeSeries: a few fixes

### DIFF
--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -103,6 +103,8 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
             else
               acc
           }
+        val allRunning = executor.allRunning
+        val allFailing = executor.allFailingExecutions
         val jobTimelines =
           for {
             job <- workflow.vertices
@@ -119,11 +121,17 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
           } yield {
             val label = jobState match {
               case Running(e) =>
-                if (executor.allFailingExecutions.exists(_.id == e))
+                if (allFailing.exists(_.id == e))
                   "failed"
-                else if (executor.platforms.exists(_.waiting.exists(_.id == e)))
-                  "waiting"
-                else "running"
+                else
+                  allRunning
+                    .find(_.id == e)
+                    .map(_.status match {
+                      case ExecutionWaiting => "waiting"
+                      case ExecutionRunning => "running"
+                      case _ => s"unknown"
+                    })
+                    .getOrElse("unknown")
               case Todo(_) => "todo"
               case Done => "successful"
             }
@@ -139,10 +147,10 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
         Json.obj(
           "summary" -> Hourly
             .split(period)
-            .map {
+            .flatMap {
               case (lo, hi) =>
                 val isInbackfill = backfillDomain.intersect(Interval(lo, hi)).toList.nonEmpty
-                val (duration, done, failing) = (for {
+                val jobSummaries = for {
                   job <- workflow.vertices
                   if filteredJobs.contains(job.id)
                   (interval, jobState) <- state(job).intersect(Interval(lo, hi)).toList
@@ -152,9 +160,16 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
                     case Running(e) => executor.allFailingExecutions.exists(_.id == e)
                     case _ => false
                   })
-                }).reduce((a, b) => (a._1 + b._1, a._2 + b._2, a._3 || b._3))
-                Interval(lo, hi) ->
-                  ((f"${done.toDouble / duration.toDouble}%1.1f", failing, isInbackfill))
+                }
+                if (jobSummaries.nonEmpty) {
+                  val (duration, done, failing) = jobSummaries
+                    .reduce((a, b) => (a._1 + b._1, a._2 + b._2, a._3 || b._3))
+                  Some(
+                    Interval(lo, hi) ->
+                      ((f"${done.toDouble / duration.toDouble}%1.1f", failing, isInbackfill)))
+                } else {
+                  None
+                }
             }
             .asJson,
           "jobs" -> jobTimelines.groupBy(_._1).mapValues(_.map(_._2)).asJson

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/intervals/IntervalMap.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/intervals/IntervalMap.scala
@@ -127,7 +127,7 @@ private[timeseries] object IntervalMap {
             middle ++
             (if (last == Top) List() else List(last, Top))
         }
-      val newIntervals = newBounds.grouped(2).toList.map { case List(l, h) => Interval(l, h) }
+      val newIntervals = newBounds.grouped(2).toList.collect { case List(l, h) if l != h => Interval(l, h) }
       new Impl(FingerTree((for {
         interval <- newIntervals
         m <- this.intersect(interval).toList

--- a/timeseries/src/test/scala/com/criteo/cuttle/timeseries/intervals/IntervalMapSpec.scala
+++ b/timeseries/src/test/scala/com/criteo/cuttle/timeseries/intervals/IntervalMapSpec.scala
@@ -1,0 +1,13 @@
+package com.criteo.cuttle.timeseries.intervals
+
+import org.scalatest.FunSuite
+
+class IntervalMapSpec extends FunSuite {
+  test("whenUndef") {
+    assert(
+      IntervalMap(Interval(0, 3) -> 42)
+        .whenIsUndef(IntervalMap(Interval(1, 2) -> "foo", Interval(2, 3) -> "bar"))
+        .toList ==
+        IntervalMap(Interval(0, 1) -> 42).toList)
+  }
+}


### PR DESCRIPTION
- fix a bug in `IntervalMap.whenIsUndef` where it would fail if the
argument had two adjacent intervals
- fix a bug in route `/api/timeseries/calendar` where it would fail if
one hour was before the startDate of every job
- stop serializing Running jobs (would cause these jobs to be stuck upon
reboot)
- correctly handle changes of a job's startDate
- correctly handle removal of a job from the graph