### PR TITLE
Database.connect shoud reuse transactor for a given DatabaseConfig

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Database.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Database.scala
@@ -160,7 +160,7 @@ private[cuttle] object Database {
 
   private val connections = collection.concurrent.TrieMap.empty[DatabaseConfig,XA]
   def connect(c: DatabaseConfig): XA = {
-    connections.getOrElseUpdate {
+    connections.getOrElseUpdate(c, {
       val xa = (for {
         hikari <- HikariTransactor[IOLite](
           "com.mysql.cj.jdbc.Driver",
@@ -174,7 +174,7 @@ private[cuttle] object Database {
       } yield hikari).unsafePerformIO
       doSchemaUpdates.transact(xa).unsafePerformIO
       lockedTransactor(xa)
-    }
+    })
   }
 }
 

--- a/core/src/main/scala/com/criteo/cuttle/Database.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Database.scala
@@ -158,20 +158,23 @@ private[cuttle] object Database {
       }
     } yield ())
 
+  private val connections = collection.concurrent.TrieMap.empty[DatabaseConfig,XA]
   def connect(c: DatabaseConfig): XA = {
-    val xa = (for {
-      hikari <- HikariTransactor[IOLite](
-        "com.mysql.cj.jdbc.Driver",
-        s"jdbc:mysql://${c.host}:${c.port}/${c.database}?serverTimezone=UTC&useSSL=false&allowMultiQueries=true",
-        c.username,
-        c.password
-      )
-      _ <- hikari.configure { datasource =>
-        IOLite.primitive( /* Configure datasource if needed */ ())
-      }
-    } yield hikari).unsafePerformIO
-    doSchemaUpdates.transact(xa).unsafePerformIO
-    lockedTransactor(xa)
+    connections.getOrElseUpdate {
+      val xa = (for {
+        hikari <- HikariTransactor[IOLite](
+          "com.mysql.cj.jdbc.Driver",
+          s"jdbc:mysql://${c.host}:${c.port}/${c.database}?serverTimezone=UTC&useSSL=false&allowMultiQueries=true",
+          c.username,
+          c.password
+        )
+        _ <- hikari.configure { datasource =>
+          IOLite.primitive( /* Configure datasource if needed */ ())
+        }
+      } yield hikari).unsafePerformIO
+      doSchemaUpdates.transact(xa).unsafePerformIO
+      lockedTransactor(xa)
+    }
   }
 }
 


### PR DESCRIPTION
Otherwise if you try to obtain the transactor several times, it will create several connection pool. Moreover because of the locking mechanism it will deadlock.