### PR TITLE
Better cancel listener design

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/platforms/local/LocalPlatform.scala
+++ b/core/src/main/scala/com/criteo/cuttle/platforms/local/LocalPlatform.scala
@@ -70,9 +70,9 @@ class LocalProcess(command: String) {
         process.setProcessListener(handler)
         val fork = process.start()
         streams.debug(s"forked with PID ${fork.getPID}")
-        execution.onCancelled(() => {
+        execution.onCancel(() => {
           fork.destroy(true)
-        })
+        }).unsubscribeOn(result.future)
         result.future
       }
   }


### PR DESCRIPTION
To avoid memory leak for long execution registering several cancel listeners,
we now allow to unsubscribe when the code is not anymore interested by the cancel
signal.