### PR TITLE
Update Metrics model.

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/App.scala
+++ b/core/src/main/scala/com/criteo/cuttle/App.scala
@@ -187,7 +187,7 @@ private[cuttle] case class App[S <: Scheduling](project: CuttleProject[S], execu
 
     case GET at "/metrics" =>
       val metrics = executor.getMetrics(allJobs) ++ scheduler.getMetrics(allJobs) :+
-        Gauge("jvm_uptime_seconds").set(getJVMUptime)
+        Gauge("cuttle_jvm_uptime_seconds").set(getJVMUptime)
       Ok(Prometheus.serialize(metrics))
 
     case GET at url"/api/executions/status/$kind?limit=$l&offset=$o&events=$events&sort=$sort&order=$a&jobs=$jobs" =>

--- a/core/src/main/scala/com/criteo/cuttle/App.scala
+++ b/core/src/main/scala/com/criteo/cuttle/App.scala
@@ -187,8 +187,8 @@ private[cuttle] case class App[S <: Scheduling](project: CuttleProject[S], execu
 
     case GET at "/metrics" =>
       val metrics = executor.getMetrics(allJobs) ++ scheduler.getMetrics(allJobs) :+
-        Gauge("jvm_uptime_seconds", getJVMUptime)
-      Ok(Prometheus.format(metrics))
+        Gauge("jvm_uptime_seconds").set(getJVMUptime)
+      Ok(Prometheus.serialize(metrics))
 
     case GET at url"/api/executions/status/$kind?limit=$l&offset=$o&events=$events&sort=$sort&order=$a&jobs=$jobs" =>
       val limit = Try(l.toInt).toOption.getOrElse(25)

--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -402,11 +402,11 @@ class Executor[S <: Scheduling] private[cuttle] (
   override def getMetrics(jobs: Set[String]): Seq[Metric] = {
     val ((running, waiting), paused, failing) = getStateAtomic(jobs)
 
-    Seq(
-      Gauge("scheduler_stat_count", running, Seq("type" -> "running")),
-      Gauge("scheduler_stat_count", waiting, Seq("type" -> "waiting")),
-      Gauge("scheduler_stat_count", paused, Seq("type" -> "paused")),
-      Gauge("scheduler_stat_count", failing, Seq("type" -> "failing"))
+    Seq(Gauge("scheduler_stat_count", "The number of jobs that we have in concrete states")
+      .labeled("type" -> "running", running)
+      .labeled("type" -> "waiting", waiting)
+      .labeled("type" -> "paused", paused)
+      .labeled("type" -> "failing", failing)
     )
   }
 

--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -402,7 +402,7 @@ class Executor[S <: Scheduling] private[cuttle] (
   override def getMetrics(jobs: Set[String]): Seq[Metric] = {
     val ((running, waiting), paused, failing) = getStateAtomic(jobs)
 
-    Seq(Gauge("scheduler_stat_count", "The number of jobs that we have in concrete states")
+    Seq(Gauge("cuttle_scheduler_stat_count", "The number of jobs that we have in concrete states")
       .labeled("type" -> "running", running)
       .labeled("type" -> "waiting", waiting)
       .labeled("type" -> "paused", paused)

--- a/core/src/main/scala/com/criteo/cuttle/Metrics.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Metrics.scala
@@ -1,7 +1,5 @@
 package com.criteo.cuttle
 
-import scala.collection.mutable.{ Map => MMap }
-
 object Metrics {
 
   object MetricType extends Enumeration {
@@ -15,31 +13,23 @@ object Metrics {
     val name: String
     val help: String
     val metricType: MetricType
-    val labels2Value: MMap[Set[(String, String)], AnyVal]
+    val labels2Value: Map[Set[(String, String)], AnyVal]
 
     def isDefined: Boolean = labels2Value.nonEmpty
   }
 
-  case class Gauge(name: String, help: String = "") extends Metric {
+  case class Gauge(name: String, help: String = "", labels2Value: Map[Set[(String, String)], AnyVal] = Map.empty)
+    extends Metric {
 
     override val metricType: MetricType = gauge
-    override val labels2Value: MMap[Set[(String, String)], AnyVal] = MMap.empty
 
-    def labeled(labels: Set[(String, String)], value: AnyVal): Gauge = {
-      labels2Value += labels -> value
-      this
-    }
+    def labeled(labels: Set[(String, String)], value: AnyVal): Gauge =
+      copy(labels2Value = labels2Value + (labels -> value))
 
-    def labeled(label: (String, String), value: AnyVal): Gauge = {
-      labels2Value += Set(label) -> value
-      this
-    }
+    def labeled(label: (String, String), value: AnyVal): Gauge =
+      copy(labels2Value = labels2Value + (Set(label) -> value))
 
-    def set(value: AnyVal): Gauge = {
-      labels2Value += Set.empty[(String, String)] -> value
-      this
-    }
-
+    def set(value: AnyVal): Gauge = copy(labels2Value = labels2Value + (Set.empty[(String, String)] -> value))
   }
 
   trait MetricProvider {

--- a/core/src/main/scala/com/criteo/cuttle/Metrics.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Metrics.scala
@@ -1,27 +1,70 @@
 package com.criteo.cuttle
 
+import scala.collection.mutable.{ Map => MMap }
+
 object Metrics {
-  sealed trait Metric {
-    def toString: String
+
+  object MetricType extends Enumeration {
+    type MetricType = Value
+    val gauge = Value
   }
 
-  case class Gauge(name: String, value: Long, tags: Seq[(String, String)] = Seq.empty) extends Metric
+  import MetricType._
+
+  sealed trait Metric {
+    val name: String
+    val help: String
+    val metricType: MetricType
+    val labels2Value: MMap[Set[(String, String)], AnyVal]
+
+    def isDefined: Boolean = labels2Value.nonEmpty
+  }
+
+  case class Gauge(name: String, help: String = "") extends Metric {
+
+    override val metricType: MetricType = gauge
+    override val labels2Value: MMap[Set[(String, String)], AnyVal] = MMap.empty
+
+    def labeled(labels: Set[(String, String)], value: AnyVal): Gauge = {
+      labels2Value += labels -> value
+      this
+    }
+
+    def labeled(label: (String, String), value: AnyVal): Gauge = {
+      labels2Value += Set(label) -> value
+      this
+    }
+
+    def set(value: AnyVal): Gauge = {
+      labels2Value += Set.empty[(String, String)] -> value
+      this
+    }
+
+  }
 
   trait MetricProvider {
     def getMetrics(jobs: Set[String]): Seq[Metric]
   }
 
   private[cuttle] object Prometheus {
-    def format(metrics: Seq[Metric]): String = {
-      val prometheusMetrics = metrics.map {
-        case Gauge(name, value, tags) =>
-          s"$name${
-            if (tags.nonEmpty) s" {${tags.map(tag => s"""${tag._1}="${tag._2}"""").mkString(", ")}}"
-            else ""
-          } $value"
+    private def serialize2PrometheusStrings[T](metric: Metric): Seq[String] = if (metric.isDefined) {
+      val labeledMetrics = metric.labels2Value.map {
+        case (labels, value) =>
+          val labelsSerialized =
+            if (labels.nonEmpty) s" {${labels.map(label => s"""${label._1}="${label._2}"""").mkString(", ")}} "
+            else " "
+          s"${metric.name}$labelsSerialized$value"
       }
 
-      s"${prometheusMetrics.mkString("\n")}\n"
-    }
+      val metricType = s"# TYPE ${metric.name} ${metric.metricType}"
+      val help = if (metric.help.nonEmpty) {
+        Seq(s"# HELP ${metric.name} ${metric.help}")
+      } else Seq.empty[String]
+
+      (help :+ metricType) ++ labeledMetrics
+    } else Seq.empty
+
+    def serialize(metrics: Seq[Metric]): String = s"${metrics.flatMap(serialize2PrometheusStrings).mkString("\n")}\n"
   }
+
 }

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -472,16 +472,15 @@ case class TimeSeriesScheduler(logger: Logger) extends Scheduler[TimeSeries] wit
   }
 
   override def getMetrics(jobs: Set[String]): Seq[Metric] = {
-    val timeOfLastSuccessGauge = Gauge("timeseries_scheduler_last_success_epoch_seconds",
-      "The seconds since a last job's success")
 
-    getTimeOfLastSuccess(jobs).foreach {
-      case (job, instant) => timeOfLastSuccessGauge.labeled(
+    val timeOfLastSuccessGauge = getTimeOfLastSuccess(jobs).foldLeft(
+      Gauge("cuttle_timeseries_scheduler_last_success_epoch_seconds", "The seconds since a last job's success")) {
+      case (gauge, (job,instant)) => gauge.labeled(
           Set("job_id" -> job.id, "job_name" -> job.name), Instant.now().getEpochSecond - instant.getEpochSecond)
     }
 
     Seq(
-      Gauge("timeseries_scheduler_stat_count", "The number of backfills")
+      Gauge("cuttle_timeseries_scheduler_stat_count", "The number of backfills")
         .labeled("type" -> "backfills",getRunningBackfillsSize(jobs)),
       timeOfLastSuccessGauge
     )

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -468,18 +468,23 @@ case class TimeSeriesScheduler(logger: Logger) extends Scheduler[TimeSeries] wit
             case _ => Instant.MAX
           })
         }
-    }.flatten
+    }.flatten.toSeq
   }
 
   override def getMetrics(jobs: Set[String]): Seq[Metric] = {
-    val timeOfLastSuccessMetrics = getTimeOfLastSuccess(jobs).map {
-      case (job, instant) =>
-        Gauge("scheduler_last_success_epoch_seconds", Instant.now().getEpochSecond - instant.getEpochSecond,
-          Seq("job_id" -> job.id, "job_name" -> job.name))
+    val timeOfLastSuccessGauge = Gauge("timeseries_scheduler_last_success_epoch_seconds",
+      "The seconds since a last job's success")
+
+    getTimeOfLastSuccess(jobs).foreach {
+      case (job, instant) => timeOfLastSuccessGauge.labeled(
+          Set("job_id" -> job.id, "job_name" -> job.name), Instant.now().getEpochSecond - instant.getEpochSecond)
     }
 
-    Seq(Gauge("scheduler_stat_count", getRunningBackfillsSize(jobs), Seq("type" -> "backfills"))) ++
-      timeOfLastSuccessMetrics
+    Seq(
+      Gauge("timeseries_scheduler_stat_count", "The number of backfills")
+        .labeled("type" -> "backfills",getRunningBackfillsSize(jobs)),
+      timeOfLastSuccessGauge
+    )
   }
 
   override def getStats(jobs: Set[String]): Json = {


### PR DESCRIPTION
Now we can add help and type prometheus like comments to our metrics.
Each Prometheus metric is defined by its name and set of labels so our metric model reflect this directly by implementing a Map: set of labels to value. 
For instance we support only a gauge type of metrics.