### PR TITLE
allow to relaunch all stuck jobs

### DIFF
--- a/core/src/main/javascript/app/pages/ExecutionLogs.js
+++ b/core/src/main/javascript/app/pages/ExecutionLogs.js
@@ -582,19 +582,28 @@ export const Stuck = connect(mapStateToProps, mapDispatchToProps)(
       selectedJobs,
       envCritical
     }) => {
-      let jobsFilter = selectedJobs.length
-        ? `&jobs=${selectedJobs.join(",")}`
-        : "";
+      const isFilterApplied = selectedJobs.length > 0;
+      const selectedJobsString = selectedJobs.join(",");
+      const jobsFilter = `jobs=${selectedJobsString}`;
+
+      const relaunch = () => {
+        fetch(
+          `/api/executions/relaunch${isFilterApplied ? `?${jobsFilter}` : ""}`,
+          {
+            method: "POST",
+            credentials: "include"
+          }
+        );
+      };
+
       return (
         <div className={classes.container}>
           <h1 className={classes.title}>Stuck executions</h1>
           <PopoverMenu
             className={classes.menu}
             items={[
-              //TODO retry stuck implementation
-              // eslint-disable-next-line no-console
-              <span onClick={console.log}>
-                Retry everything now
+              <span onClick={relaunch}>
+                Relaunch everything now
               </span>
             ]}
           />
@@ -613,7 +622,7 @@ export const Stuck = connect(mapStateToProps, mapDispatchToProps)(
               "detail"
             ]}
             request={(page, rowsPerPage, sort) =>
-              `/api/executions/status/stuck?events=true&offset=${page * rowsPerPage}&limit=${rowsPerPage}&sort=${sort.column}&order=${sort.order}${jobsFilter}`}
+              `/api/executions/status/stuck?events=true&offset=${page * rowsPerPage}&limit=${rowsPerPage}&sort=${sort.column}&order=${sort.order}${jobsFilter}${isFilterApplied ? `&${jobsFilter}` : ""}`}
             label="stuck"
             sort={{ column: sort || "failed", order }}
             selectedJobs={selectedJobs}

--- a/core/src/main/scala/com/criteo/cuttle/App.scala
+++ b/core/src/main/scala/com/criteo/cuttle/App.scala
@@ -311,6 +311,17 @@ private[cuttle] case class App[S <: Scheduling](project: CuttleProject[S],
         Ok
       }
     }
+
+    case POST at url"/api/executions/relaunch?jobs=$jobs" => { implicit user =>
+      val filteredJobs = Try(jobs.split(",").toSeq.filter(_.nonEmpty)).toOption
+        .filter(_.nonEmpty)
+        .getOrElse(allJobs)
+        .toSet
+
+      executor.relaunch(filteredJobs)
+      Ok
+    }
+
     case GET at url"/api/shutdown?gracePeriodSeconds=$gracePeriodSeconds" => { implicit user =>
       import scala.concurrent.duration._
 

--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -267,7 +267,7 @@ case class Execution[S <: Scheduling](
   /**
     * Run this execution on its job.
     */
-  def run(): Future[Completed] =
+  private[cuttle] def run(): Future[Completed] =
     job.run(this)
 }
 
@@ -629,7 +629,7 @@ class Executor[S <: Scheduling] private[cuttle] (val platforms: Seq[ExecutionPla
             execution.streams.error(stacktrace.toString)
             atomic {
               implicit tx =>
-                // retain jobs in a recent failures if a last failure happened in [now - retryStrategy.retryWindow, now]
+                // retain jobs in recent failures if last failure happened in [now - retryStrategy.retryWindow, now]
                 recentFailures.retain {
                   case (_, (retryExecution, failingJob)) =>
                     retryExecution.isDefined || failingJob.isLastFailureAfter(

--- a/core/src/main/scala/com/criteo/cuttle/Workflow.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Workflow.scala
@@ -137,5 +137,5 @@ case class Job[S <: Scheduling](id: String,
     * @param execution The execution instance.
     * @return A future indicating the execution result (Failed future means failed execution).
     */
-  def run(execution: Execution[S]): Future[Completed] = effect(execution)
+  private[cuttle] def run(execution: Execution[S]): Future[Completed] = effect(execution)
 }

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -94,7 +94,7 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
                                             xa: XA): PartialService = {
 
     case request @ GET at url"/api/timeseries/executions?job=$jobId&start=$start&end=$end" =>
-      def watchState() = Some((state, executor.allFailing))
+      def watchState() = Some((state, executor.allFailingJobsWithContext))
 
       def getExecutions(watchedValue: Any = ()) = {
         val job = workflow.vertices.find(_.id == jobId).get
@@ -172,7 +172,7 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
         .getOrElse(workflow.vertices.map(_.id))
         .toSet
 
-      def watchState() = Some((state, executor.allFailing))
+      def watchState() = Some((state, executor.allFailingJobsWithContext))
 
       def getFocusView(watchedValue: Any = ()) = {
         val startDate = Instant.parse(start)
@@ -325,7 +325,7 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
         .getOrElse(workflow.vertices.map(_.id))
         .toSet
 
-      def watchState() = Some((state, executor.allFailing))
+      def watchState() = Some((state, executor.allFailingJobsWithContext))
 
       def getCalendar(watchedValue: Any = ()) = {
         val (state, backfills) = this.state


### PR DESCRIPTION
- new route /api/executions/relaunch?jobs=
- new method in Executor `def relaunch` that  is invoked by new route
- code rearrangement in Executor
