### PR TITLE
remove companion object that was shadowing an apply function

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/platforms/local/LocalPlatform.scala
+++ b/core/src/main/scala/com/criteo/cuttle/platforms/local/LocalPlatform.scala
@@ -29,10 +29,6 @@ case class LocalPlatform(maxForkedProcesses: Int) extends ExecutionPlatform {
     pool.routes("/api/platforms/local/pool")
 }
 
-private[cuttle] object LocalPlatform {
-  def fork(command: String) = new LocalProcess(command)
-}
-
 /** Represent a process to be locally foked.
   *
   * @param command The actual command to be run in a new `shell`.

--- a/core/src/main/scala/com/criteo/cuttle/platforms/local/package.scala
+++ b/core/src/main/scala/com/criteo/cuttle/platforms/local/package.scala
@@ -28,7 +28,7 @@ package object local {
   /** The __exec__ string interpolation. */
   implicit class InlineCommands(val sc: StringContext) extends AnyVal {
     def exec(args: Any*) =
-      LocalPlatform.fork(sc.parts.zipAll(args, "", "").map { case (a, b) => a + b }.mkString.stripMargin)
+      new LocalProcess(sc.parts.zipAll(args, "", "").map { case (a, b) => a + b }.mkString.stripMargin)
   }
 
 }


### PR DESCRIPTION
`private[cuttle] object LocalPlatform` restricts usage of LocalPlatform's apply function outside of cuttle package