### PR TITLE
Use dedicated ExecutionContexts

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/CuttleProject.scala
+++ b/core/src/main/scala/com/criteo/cuttle/CuttleProject.scala
@@ -1,7 +1,8 @@
 package com.criteo.cuttle
 
 import lol.http._
-import scala.concurrent.ExecutionContext.Implicits.global
+
+import com.criteo.cuttle.ExecutionContexts._, Implicits.serverExecutionContext
 
 /**
   * A cuttle project is a workflow to execute with the appropriate scheduler.
@@ -78,8 +79,9 @@ object CuttleProject {
     new CuttleProject(name, version, description, env, workflow, scheduler, authenticator, logger)
 
   private[CuttleProject] def defaultPlatforms: Seq[ExecutionPlatform] = {
+    import java.util.concurrent.TimeUnit.SECONDS
+
     import platforms._
-    import java.util.concurrent.TimeUnit.{SECONDS}
 
     Seq(
       local.LocalPlatform(

--- a/core/src/main/scala/com/criteo/cuttle/ExecutionContexts.scala
+++ b/core/src/main/scala/com/criteo/cuttle/ExecutionContexts.scala
@@ -1,0 +1,77 @@
+package com.criteo.cuttle
+
+import java.util.concurrent.Executors
+
+import scala.concurrent.ExecutionContext
+import scala.language.implicitConversions
+import scala.util.Try
+
+object ExecutionContexts {
+
+  sealed trait WrappedExecutionContext {
+    val underlying: ExecutionContext
+  }
+
+  sealed trait Metrics {
+    protected var _threadPoolSize: Long = 0
+    def threadPoolSize(): Long = _threadPoolSize
+  }
+
+  implicit def serverECToEC(ec: ServerExecutionContext): ExecutionContext = ec.underlying
+  implicit def sideEffectECToEC(ec: SideEffectExecutionContext): ExecutionContext = ec.underlying
+  implicit def implicitServerECToEC(implicit ec: ServerExecutionContext): ExecutionContext = ec.underlying
+  implicit def implicitSideEffectECToEC(implicit ec: SideEffectExecutionContext): ExecutionContext = ec.underlying
+
+  sealed trait ServerExecutionContext extends WrappedExecutionContext with Metrics
+
+  // dedicated threadpool to start new executions and run user-defined side effects
+  sealed trait SideEffectExecutionContext extends WrappedExecutionContext with Metrics
+
+  // The implicitly provided execution contexts use fixed thread pools.
+  // These thread pool default sizes are overridable with Java system properties, passing -D<property_name> <value> flags when you start the JVM
+  object ThreadPoolSystemProperties extends Enumeration {
+    type ThreadPoolSystemProperties = Value
+    val ServerECThreadCount = Value("com.criteo.cuttle.ExecutionContexts.ServerExecutionContext.nThreads")
+    val SideEffectECThreadCount = Value("com.criteo.cuttle.ExecutionContexts.SideEffectExecutionContext.nThreads")
+
+    def fromSystemProperties(value: ThreadPoolSystemProperties.Value, defaultValue: Int): Int =
+      loadSystemPropertyAsInt(value.toString, defaultValue)
+
+    private def loadSystemPropertyAsInt(propertyName: String, defaultValue: Int) = {
+      Option(System.getProperties().getProperty(propertyName)) match {
+        case Some(size) => Try[Int] { size.toInt }.getOrElse(Runtime.getRuntime.availableProcessors)
+        case None => Runtime.getRuntime.availableProcessors
+      }
+    }
+  }
+
+  object Implicits {
+    import ThreadPoolSystemProperties._
+    implicit val serverExecutionContext = new ServerExecutionContext {
+      override val underlying = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(
+        fromSystemProperties(ServerECThreadCount, Runtime.getRuntime.availableProcessors),
+        utils.createThreadFactory(
+          (r: Runnable) => {
+            val t = Executors.defaultThreadFactory.newThread(r)
+            _threadPoolSize += 1
+            t.setDaemon(true)
+            t.setPriority(Thread.MAX_PRIORITY)
+            t
+          })
+      ))
+    }
+
+    implicit val sideEffectExecutionContext = new SideEffectExecutionContext {
+      override val underlying = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(
+        fromSystemProperties(SideEffectECThreadCount, Runtime.getRuntime.availableProcessors),
+        utils.createThreadFactory(
+          (r: Runnable) => {
+            val t = Executors.defaultThreadFactory.newThread(r)
+            _threadPoolSize += 1
+            t.setDaemon(true)
+            t
+          })
+      ))
+    }
+  }
+}

--- a/core/src/main/scala/com/criteo/cuttle/Utils.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Utils.scala
@@ -21,18 +21,12 @@ package object utils {
     * after the given duration.
     */
   object Timeout {
-    private val scheduler = Executors.newScheduledThreadPool(1, new ThreadFactory() {
-      def newThread(r: Runnable): Thread = {
-        val t = Executors.defaultThreadFactory.newThread(r)
-        t.setDaemon(true)
-        t
-      }
-    })
+    private val scheduler = Executors.newScheduledThreadPool(1, createDaemonThreadFactory())
 
     /** Creates a  [[scala.concurrent.Future]] that resolve automatically
       * after the given duration.
       *
-      * @param duration Duration for the timeout.
+      * @param timeout Duration for the timeout.
       */
     def apply(timeout: Duration): Future[Unit] = {
       val p = Promise[Unit]()
@@ -69,4 +63,20 @@ package object utils {
   }
 
   private[cuttle] def getJVMUptime = ManagementFactory.getRuntimeMXBean.getUptime / 1000
+
+  private[cuttle] def createDaemonThreadFactory(): ThreadFactory {
+    def newThread(r: Runnable): Thread
+  } = new ThreadFactory() {
+    def newThread(r: Runnable): Thread = {
+      val t = Executors.defaultThreadFactory.newThread(r)
+      t.setDaemon(true)
+      t
+    }
+  }
+
+  private[cuttle] def createThreadFactory(newThreadImpl: Runnable => Thread): ThreadFactory {
+    def newThread(r: Runnable): Thread
+  } = new ThreadFactory() {
+    def newThread(r: Runnable): Thread = newThreadImpl(r)
+  }
 }

--- a/core/src/main/scala/com/criteo/cuttle/package.scala
+++ b/core/src/main/scala/com/criteo/cuttle/package.scala
@@ -1,10 +1,10 @@
 package com.criteo
 
-import cats.effect.IO
-
 import scala.concurrent._
-import doobie.imports._
+
+import cats.effect.IO
 import cats.free._
+import doobie.imports._
 
 package cuttle {
 
@@ -48,7 +48,7 @@ package object cuttle {
     * discarding, but [[Completed]] do not maintain additional state).
     *
     * The cuttle [[Executor]] ensures that a scheduled side effect for a given [[SchedulingContext]] will be run
-    * a least once, but cannot garantee that it will be run execactly once. That's why the side effect function must
+    * a least once, but cannot guarantee that it will be run exactly once. That's why the side effect function must
     * be idempotent, meaning that if executed for the same [[SchedulingContext]] it must produce the same result.
     *
     * A failed future means a failed execution.
@@ -59,7 +59,7 @@ package object cuttle {
     * Automatically provide a scala `scala.concurrent.ExecutionContext` for a given [[Execution]].
     * The threadpool will be chosen carefully by the [[Executor]].
     */
-  implicit def scopedExecutionContext(implicit execution: Execution[_]) = execution.executionContext
+  implicit def scopedExecutionContext(implicit execution: Execution[_]): ExecutionContext = execution.executionContext
 
   /** Default implicit logger that output everything to __stdout__ */
   implicit val logger = new Logger {

--- a/core/src/main/scala/com/criteo/cuttle/platforms/http/HttpPlatform.scala
+++ b/core/src/main/scala/com/criteo/cuttle/platforms/http/HttpPlatform.scala
@@ -1,17 +1,18 @@
 package com.criteo.cuttle.platforms.http
 
-import com.criteo.cuttle._
-import platforms.{ExecutionPool, RateLimiter}
+import java.util.concurrent.TimeUnit
 
 import scala.concurrent._
-import java.util.concurrent.TimeUnit
 
 import cats.effect.IO
 import io.circe._
 import io.circe.syntax._
-
 import lol.http._
 import lol.json._
+
+import com.criteo.cuttle._
+import com.criteo.cuttle.platforms.{ExecutionPool, RateLimiter}
+
 
 /** Allow to make HTTP calls in a managed way with rate limiting. Globally the platform limits the number
   * of concurrent requests on the platform. Additionnaly a rate limiter must be defined for each host allowed

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -1,30 +1,31 @@
 package com.criteo.cuttle.timeseries
 
-import TimeSeriesUtils._
-import com.criteo.cuttle._
-import lol.http._
-import lol.json._
-import io.circe._
-import io.circe.syntax._
-import io.circe.generic.auto._
-
-import scala.util.Try
 import java.time.Instant
 import java.time.temporal.ChronoUnit._
 
-import doobie.implicits._
-import intervals._
-import Bound.{Bottom, Finite, Top}
-import ExecutionStatus._
-import Auth._
+import scala.util.Try
+
 import cats.effect.IO
 import cats.implicits._
+import doobie.implicits._
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.syntax._
+import lol.http._
+import lol.json._
+
+import com.criteo.cuttle.Auth._
+import com.criteo.cuttle.ExecutionStatus._
+import com.criteo.cuttle._
+import com.criteo.cuttle.timeseries.TimeSeriesUtils._
+import com.criteo.cuttle.timeseries.intervals.Bound.{Bottom, Finite, Top}
+import com.criteo.cuttle.timeseries.intervals._
 
 private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
 
   import App._
-  import TimeSeriesCalendar._
   import JobState._
+  import TimeSeriesCalendar._
 
   private implicit val intervalEncoder = new Encoder[Interval[Instant]] {
     implicit val boundEncoder = new Encoder[Bound[Instant]] {


### PR DESCRIPTION
The split is as follows:
- 1 thread pool for Cuttle's HTTP server with low thread limit
- 1 thread pool to run side effects
- 1 thread pool for internal use by side effects (which returns Futures from an execution context)

Other: fixed some typos