### PR TITLE
remove debug output from local platform

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/platforms/local/LocalPlatform.scala
+++ b/core/src/main/scala/com/criteo/cuttle/platforms/local/LocalPlatform.scala
@@ -41,8 +41,7 @@ class LocalProcess(command: String) {
     errLogger: (String) => Unit
   )(implicit execution: Execution[S]): Future[Completed] = {
     val streams = execution.streams
-    streams.debug(s"Forking:")
-    streams.debug(this.toString)
+    streams.debug("Forking Process...")
 
     ExecutionPlatform
       .lookup[LocalPlatform]


### PR DESCRIPTION
We need to do this because forked command can contain credentials and we don't want to show it to users.