### PR TITLE
allow to parametrize executions log size

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Authentication.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Authentication.scala
@@ -38,7 +38,7 @@ object Auth {
     /**
       * Authenticate an HTTP request.
       *
-      * @param rrequest the HTTP request to be authenticated.
+      * @param request the HTTP request to be authenticated.
       * @return either an authenticated user or an error response.
       */
     def authenticate(request: Request): Either[Response, User]

--- a/core/src/main/scala/com/criteo/cuttle/ExecutionStreams.scala
+++ b/core/src/main/scala/com/criteo/cuttle/ExecutionStreams.scala
@@ -13,13 +13,14 @@ import scala.concurrent.stm._
 trait ExecutionStreams {
 
   /** Output info messages */
-  def info(str: CharSequence = "") = this.writeln("INFO ", str)
+  def info(str: CharSequence = ""): Unit = this.writeln("INFO ", str)
 
   /** Output error messages */
-  def error(str: CharSequence = "") = this.writeln("ERROR", str)
+  def error(str: CharSequence = ""): Unit = this.writeln("ERROR", str)
 
   /** Output debug messages (usually used by the [[ExecutionPlatform]]) */
-  def debug(str: CharSequence = "") = this.writeln("DEBUG", str)
+  def debug(str: CharSequence = ""): Unit = this.writeln("DEBUG", str)
+
   private def writeln(tag: String, str: CharSequence): Unit = {
     val time = Instant.now.toString
     str.toString.split("\n").foreach(l => this.writeln(s"$time $tag - $l"))
@@ -30,9 +31,17 @@ trait ExecutionStreams {
 private[cuttle] object ExecutionStreams {
   private type ExecutionId = String
   private type LastUsageTime = Long
+
   private val transientStorage = Files.createTempDirectory("cuttle-logs").toFile
   private val openHandles = TMap.empty[ExecutionId, (PrintWriter, LastUsageTime)]
   private val maxHandles = 1024
+  // Size of string to be stored in MySQL MEDIUMTEXT column, must be >= 0 and <= 16,777,215 bytes = 16 MiB.
+  // By default our heuristic is 512Kb = 524288 bytes.
+  // This can be overridden with com.criteo.cuttle.maxExecutionLogSize JVM property.
+  // Note that we are limited by Int.maxValue
+  private val maxExecutionLogSizeProp = "com.criteo.cuttle.maxExecutionLogSize"
+  private val maxExecutionLogSize = sys.props.get(maxExecutionLogSizeProp).map(_.toInt).getOrElse(524288)
+
   private implicit val S = fs2.Strategy.fromExecutionContext(global)
   private implicit val SC = fs2.Scheduler.fromFixedDaemonPool(1, "com.criteo.cuttle.ExecutionStreams.SC")
   logger.info(s"Transient execution streams go to $transientStorage")
@@ -98,19 +107,24 @@ private[cuttle] object ExecutionStreams {
     w.flush()
   }
 
+  // Logs of an execution as a string.
+  // These logs are stored in MySQL column with type MEDIUMTEXT.
+  // This column can take up to 16,777,215 (224−1) bytes = 16 MiB.
+  // By default our heuristic is maxExecutionLogSize.
+  // @param id UUID of execution
+  // @return executions logs, truncated to size of maxExecutionLogSize
   def streamsAsString(id: ExecutionId): Option[String] = {
     val f = logFile(id)
     if (f.exists) {
-      val limit = 1024 * 64
-      val buffer = Array.ofDim[Byte](limit)
+      val buffer = Array.ofDim[Byte](maxExecutionLogSize)
       val in = new FileInputStream(f)
       try {
         val size = in.read(buffer)
         if (size >= 0) {
           Some {
             val content = new String(buffer, 0, size, "utf8")
-            if (f.length > limit) {
-              content + "\n--- CONTENT TRUNCATED AT 64kb --"
+            if (f.length > maxExecutionLogSize) {
+              content + s"\n--- CONTENT TRUNCATED AT $maxExecutionLogSize BYTES --"
             } else {
               content
             }


### PR DESCRIPTION
Executions logs are stored in MySQL table in a column of type MEDIUMTEXT taht allows up to 16,777,215 bytes = 16 MiB values.
We truncated our log to 64kb before and for some applications it were too little.
Now a Cuttle User can override this value by setting a JVM property  com.criteo.cuttle.maxExecutionLogSize
I also increased our heuristically calculated default value for this setting as 512Kb or 524,288 bytes.
  