### PR TITLE
Tag metrics

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/App.scala
+++ b/core/src/main/scala/com/criteo/cuttle/App.scala
@@ -213,9 +213,10 @@ private[cuttle] case class App[S <: Scheduling](project: CuttleProject[S], execu
         .map(stats => Ok(stats.asJson))
 
     case GET at "/metrics" =>
-      val metrics = executor.getMetrics(allIds, workflow) ++ executor.getMetricsByTag(allIds) ++
-        scheduler.getMetrics(allIds, workflow) ++ scheduler.getMetricsByTag(allIds) :+
-        Gauge("cuttle_jvm_uptime_seconds").set(getJVMUptime)
+      val metrics =
+        executor.getMetrics(allIds, workflow) ++
+          scheduler.getMetrics(allIds, workflow) :+
+          Gauge("cuttle_jvm_uptime_seconds").set(getJVMUptime)
       Ok(Prometheus.serialize(metrics))
 
     case GET at url"/api/executions/status/$kind?limit=$l&offset=$o&events=$events&sort=$sort&order=$a&jobs=$jobs" =>

--- a/core/src/main/scala/com/criteo/cuttle/Metrics.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Metrics.scala
@@ -43,7 +43,6 @@ object Metrics {
   /** Components able to provide metrics. */
   trait MetricProvider[S <: Scheduling] {
     def getMetrics(jobs: Set[String], workflow: Workflow[S]): Seq[Metric]
-    def getMetricsByTag(jobs: Set[String]): Seq[Metric]
   }
 
   private[cuttle] object Prometheus {

--- a/examples/src/main/scala/com/criteo/cuttle/examples/HelloWorld.scala
+++ b/examples/src/main/scala/com/criteo/cuttle/examples/HelloWorld.scala
@@ -36,7 +36,7 @@ object HelloWorld {
     // __hello1__ is defined as a job computing hourly partitions starting at the start
     // date declared before.
     val hello1 =
-      Job("hello1", hourly(start), "Hello 1") {
+      Job("hello1", hourly(start), "Hello 1", tags = Set(Tag("hello"))) {
         // The side effect function takes the execution as parameter. The execution
         // contains useful meta data as well as the __context__ which is basically the
         // input data for our execution.
@@ -71,19 +71,19 @@ object HelloWorld {
     // Here is our third job. Look how we can also define some metadata such as a human friendly
     // name and a set of tags. This information is used in the UI to help retrieving your jobs.
     val hello3 =
-      Job("hello3", hourly(start), "Hello 3", tags = Set(Tag("unsafe job"))) { implicit e =>
+      Job("hello3", hourly(start), "Hello 3", tags = Set(Tag("hello"), Tag("unsafe"))) { implicit e =>
         // Here we mix a Scala code execution and a sh script execution.
         e.streams.info("Hello 3 from an unsafe job")
         val completed = exec"sleep 3" ()
 
         completed.map { _ =>
-          // We generate an artifical failure if the partition is for 2 days ago between 00 and 01
+          // We generate an artificial failure if the partition is for 2 days ago between 00 and 01
           // and if the `/tmp/hello3_success` file does not exist.
           if (e.context.start == LocalDate.now.minusDays(2).atStartOfDay.toInstant(UTC)
               && !new java.io.File("/tmp/hello3_success").exists) {
             e.streams.error("Oops, please create the /tmp/hello3_success file to make this execution pass...")
 
-            // Throwing an execption is enough to fail the execution, but you can also return
+            // Throwing an exception is enough to fail the execution, but you can also return
             // a failed Future.
             sys.error("Oops!!!")
           } else {
@@ -99,7 +99,7 @@ object HelloWorld {
     // Our last job is a daily job. For the daily job we still need to annouce a start date, plus
     // we need to define the time zone for which _days_ must be considered. The partitions for
     // daily jobs will usually be 24 hours, unless you are choosing a time zone with light saving.
-    val world = Job("world", daily(UTC, start), "World") { implicit e =>
+    val world = Job("world", daily(UTC, start), "World", tags = Set(Tag("world"))) { implicit e =>
       e.streams.info("World!")
       // Here we compose our executions in a for-comprehension.
       for {

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -391,7 +391,6 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
         Ok(getCalendar())
 
     case GET at url"/api/timeseries/lastruns?job=$jobId" =>
-
       val (state, _) = this.state
 
       val successfulIntervalMaps = state
@@ -403,12 +402,13 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
       if (successfulIntervalMaps.isEmpty) NotFound
       else {
         (successfulIntervalMaps.head._1.hi, successfulIntervalMaps.last._1.hi) match {
-          case (Finite(lastCompleteTime), Finite(lastTime)) => Ok(
-            Json.obj(
-              "lastCompleteTime" -> lastCompleteTime.asJson,
-              "lastTime" -> lastTime.asJson
+          case (Finite(lastCompleteTime), Finite(lastTime)) =>
+            Ok(
+              Json.obj(
+                "lastCompleteTime" -> lastCompleteTime.asJson,
+                "lastTime" -> lastTime.asJson
+              )
             )
-          )
           case _ => BadRequest
         }
       }

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -604,25 +604,6 @@ case class TimeSeriesScheduler(logger: Logger) extends Scheduler[TimeSeries] wit
     ) ++ latencies
   }
 
-  override def getMetricsByTag(jobs: Set[String]): Seq[Metric] = {
-    val averageLastSuccess = getTimeOfLastSuccess(jobs)
-      .flatMap {
-        case (job, instant) =>
-          job.tags.map(_.name -> instant)
-      }
-      .groupBy(_._1)
-      .mapValues { xs =>
-        xs.map { case (_, instant) => Instant.now().getEpochSecond - instant.getEpochSecond }.sum / xs.size
-      }
-      .foldLeft(
-        Gauge(
-          "cuttle_timeseries_scheduler_last_success_epoch_seconds_avg_by_tag",
-          "The average seconds since last success of all jobs with the same tag"
-        )
-      ) { case (gauge, (tag, avg)) => gauge.labeled("tag" -> tag, avg) }
-    Seq(averageLastSuccess)
-  }
-
   override def getStats(jobs: Set[String]): Json =
     Map("backfills" -> getRunningBackfillsSize(jobs)).asJson
 

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -592,7 +592,8 @@ case class TimeSeriesScheduler(logger: Logger) extends Scheduler[TimeSeries] wit
       case (gauge, latencyValues) =>
         latencyValues.foldLeft(gauge) {
           case (gauge, (job, latency)) =>
-            gauge.labeled(Set("job_id" -> job.id, "job_name" -> job.name), latency)
+            val tags = if (!job.tags.isEmpty) Set("tags" -> job.tags.map(_.name).mkString(",")) else Nil
+            gauge.labeled(Set("job_id" -> job.id, "job_name" -> job.name) ++ tags, latency)
         }
     }
 


### PR DESCRIPTION
Add tags to metrics that allows any prometheus aggregates instead of code avg aggregate.
Example: `max(cuttle_timeseries_scheduler_absolute_latency_epoch_seconds{tags=~"^(.*,)?hello(,.*)?$"})`