### PR TITLE
Separate low and high bounds in TimeSeriesDependency

### DIFF
--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -537,11 +537,12 @@ case class TimeSeriesScheduler(logger: Logger) extends Scheduler[TimeSeries] wit
 
     def reverseDescr(dep: TimeSeriesDependency) =
       TimeSeriesDependency(dep.offsetHigh.negated, dep.offsetLow.negated)
-    def applyDep(dep: TimeSeriesDependency) = Function.unlift { (i: Interval[Instant]) =>
-      val low = i.lo.map(_.plus(dep.offsetLow))
-      val high = i.hi.map(_.plus(dep.offsetHigh))
-      if (low >= high) None else Some(Interval(low, high))
-    }
+    def applyDep(dep: TimeSeriesDependency): PartialFunction[Interval[Instant], Interval[Instant]] =
+      Function.unlift { (i: Interval[Instant]) =>
+        val low = i.lo.map(_.plus(dep.offsetLow))
+        val high = i.hi.map(_.plus(dep.offsetHigh))
+        if (low >= high) None else Some(Interval(low, high))
+      }
 
     workflow.vertices.toList.flatMap { job =>
       val full = IntervalMap[Instant, Unit](Interval[Instant](Bottom, Top) -> (()))

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/package.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/package.scala
@@ -47,9 +47,9 @@ package object timeseries {
   }
 
   /** Defines an implicit default dependency descriptor for [[TimeSeries]] graphs.
-    * The default is `offset = 0`. */
+    * The default is `offsetLow = 0, offsetHigh = 0`. */
   implicit val defaultDependencyDescriptor: TimeSeriesDependency =
-    TimeSeriesDependency(0.hours)
+    TimeSeriesDependency(0.hours, 0.hours)
 
   /** Defines an hourly calendar starting at the specified instant. Hours are defined as
     * complete calendar hours starting at 00 minutes, 00 seconds.


### PR DESCRIPTION
This allows to depend on multiple periods through one dependency. The
meaning of the offset has also been reversed. An offset is now applied
to the desired period to get the period the dependency has to satisfy.