### PR TITLE
Refactor graph validation to reduce complexity from O(VE) to O(V+E)

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/graph/mutable/Graph.scala
+++ b/core/src/main/scala/com/criteo/cuttle/graph/mutable/Graph.scala
@@ -1,0 +1,38 @@
+package com.criteo.cuttle.graph.mutable
+
+import scala.collection.mutable
+
+private[cuttle] case class Node[T](data: T, children: mutable.Set[Node[T]] = mutable.Set.empty[Node[T]]) {
+  private var inDegree: Long = 0
+
+  def addChild(child: Node[T]): Boolean = {
+    val childAdded = children.add(child)
+    if (childAdded) child.inDegree += 1
+    childAdded
+  }
+
+  def removeChild(child: Node[T]): Boolean = {
+    val childRemoved = children.remove(child)
+    if (childRemoved) child.inDegree -= 1
+    childRemoved
+  }
+
+  /** @return true if the node has no incoming edges */
+  def isOrphanNode: Boolean = inDegree == 0
+
+  // Override hash computation to prevent stack overflow when trying to compute the hash of a node using the
+  // default hash method on graphs with cycles
+  override def hashCode(): Int = data.hashCode()
+}
+
+/** Represents a graph with an adjacency list */
+private[cuttle] case class Graph[T](nodes: Seq[Node[T]])
+
+private[cuttle] object Graph {
+  /** @param edges set of edges defined as a pair (parent, child) */
+  def fromVertexAndEdgeList[T](vertices: Set[T], edges: Set[(T, T)]): Graph[T] = {
+    val verticesWithMetadata = vertices.map(data => data -> Node(data)).toMap
+    edges.foreach { case (parent, child) => verticesWithMetadata(parent).addChild(verticesWithMetadata(child)) }
+    Graph(verticesWithMetadata.values.toSeq)
+  }
+}

--- a/core/src/main/scala/com/criteo/cuttle/graph/package.scala
+++ b/core/src/main/scala/com/criteo/cuttle/graph/package.scala
@@ -1,0 +1,37 @@
+package com.criteo.cuttle
+
+import scala.collection.mutable.{Set => MutableSet}
+import scala.collection.mutable.ListBuffer
+
+import com.criteo.cuttle.graph.mutable.{Node => MutableNode}
+import com.criteo.cuttle.graph.mutable.{Graph => MutableGraph}
+
+package object graph {
+  /**
+    * @param edges set of edges defined as a pair (parent, child)
+    * @return the nodes in `graph` sorted in topological order, None if the graph contains a cycle
+    * @note Kahn's algorithm
+    * */
+  def topologicalSort[T](vertices: Set[T], edges: Set[(T, T)]): Option[List[T]] = {
+    val topologicalOrder = ListBuffer.empty[MutableNode[T]]
+
+    val graph = MutableGraph.fromVertexAndEdgeList(vertices, edges)
+
+    val nodesToVisit = MutableSet(graph.nodes.filter(_.isOrphanNode): _*)
+
+    while (nodesToVisit.nonEmpty) {
+      val orphanNode = nodesToVisit.head
+      topologicalOrder.append(orphanNode)
+      nodesToVisit.remove(orphanNode)
+
+      orphanNode.children.foreach { child =>
+        // edgeVisitor(root.node, child.node)
+        orphanNode.removeChild(child)
+        if (child.isOrphanNode) nodesToVisit.add(child)
+      }
+    }
+
+    val hasCycle = !graph.nodes.forall(node => node.isOrphanNode)
+    if(hasCycle) None else Some(topologicalOrder.map(_.data).toList)
+  }
+}

--- a/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSpec.scala
+++ b/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSpec.scala
@@ -3,10 +3,11 @@ package com.criteo.cuttle.timeseries
 import java.time._
 import java.time.temporal.ChronoUnit._
 
+import org.scalatest.FunSuite
+
 import com.criteo.cuttle._
 import com.criteo.cuttle.timeseries.intervals.Bound.{Finite, Top}
 import com.criteo.cuttle.timeseries.intervals._
-import org.scalatest.FunSuite
 
 class TimeSeriesSpec extends FunSuite with TestScheduling {
   val scheduling: TimeSeries = hourly(date"2017-03-25T02:00:00Z")
@@ -79,7 +80,11 @@ class TimeSeriesSpec extends FunSuite with TestScheduling {
 
     val validationRes = TimeSeriesUtils.validate(workflow)
     assert(validationRes.isLeft, "workflow passed start date validation")
-    assert(validationRes.left.get === List("Workflow has at least one cycle"), "errors messages are bad")
+    assert(validationRes.left.get === List(
+      "Workflow has at least one cycle",
+      "Job [0] starts at [2017-03-25T02:00:00Z] before his parent [badJob] at [2117-03-25T02:00:00Z]",
+      "Job [1] starts at [2017-03-25T02:00:00Z] before his parent [badJob] at [2117-03-25T02:00:00Z]"
+    ), "errors messages are bad")
   }
 
   test("it shouldn't validate a workflow that contains jobs with same ids") {


### PR DESCRIPTION
V being the number of jobs and E the number of dependencies

Supersedes https://github.com/criteo/cuttle/pull/236 taking into @loicknuchel comments and drops the cycle identification for this change.

See `TimeSeriesUtils.validate()`
