### PR TITLE
Fixes race condition in waiting execution queue

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/platforms/WaitingExecutionQueue.scala
+++ b/core/src/main/scala/com/criteo/cuttle/platforms/WaitingExecutionQueue.scala
@@ -37,7 +37,11 @@ trait WaitingExecutionQueue {
   }
 
   lazy val _running = Ref(Set.empty[(Execution[_], DelayedResult[_])])
-  lazy val _waiting = Ref(SortedSet.empty[(Execution[_], DelayedResult[_])](Ordering.by(_._1)))
+  lazy val _waiting = Ref(
+    SortedSet.empty[(Execution[_ <: Scheduling], DelayedResult[_])](
+      Ordering.by[(Execution[_ <: Scheduling], DelayedResult[_]), (Execution[_], Int)]({
+        case (execution, delayedResult) => execution -> delayedResult.hashCode
+      })))
 
   def waiting: Set[Execution[_]] = _waiting.single().map(_._1)
   def running: Set[Execution[_]] = _running.single().map(_._1)


### PR DESCRIPTION
When several actions were queued concurrently in the same
WaitingExecutionQueue, only the last one remained.