### PR TITLE
Resolve backfills on valid subperiods

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -372,7 +372,7 @@ class Executor[S <: Scheduling] private[cuttle] (val platforms: Seq[ExecutionPla
     val pausedJobs = queries.getPausedJobs.transact(xa).unsafeRunSync
     TMap(pausedJobs.map(pausedJob => pausedJob.id -> pausedJob.toPausedJobWithExecutions[S]()): _*)
   }
-  private val runningState = TMap.empty[Execution[S], Future[Completed]]
+  private[cuttle] val runningState = TMap.empty[Execution[S], Future[Completed]]
   private val throttledState = TMap.empty[Execution[S], (Promise[Completed], FailingJob)]
   private val recentFailures = TMap.empty[(Job[S], S#Context), (Option[Execution[S]], FailingJob)]
 

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -538,6 +538,7 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
                               backfill.startDate,
                               backfill.endDate,
                               backfill.priority,
+                              executor.runningState,
                               xa).map {
                     case Right(_)     => Ok("ok".asJson)
                     case Left(errors) => BadRequest(errors)


### PR DESCRIPTION
Automatically resolve valid backfills on subperiods instead of requesting the backfill to be valid on the whole input period.
Assume a backfill is requested over the period t1, t2 for the jobs = {job1, job2}
For illustrative purposes, let the past execution state be as follows:
```
| time | t1 | t2 | t3 | t4 | t5 |
| job1 | OK | OK | KO | OK | OK |
| job2 | OK | OK | KO | KO | OK |
````

Then the backfill will be lauched on {t1, t2} for jobs {job1, job2}, on {t4} for {job1} and on {t5} for {job1, job2}