### PR TITLE
Send dates instead of instants in /api/timeseries/calendar

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/App.scala
+++ b/core/src/main/scala/com/criteo/cuttle/App.scala
@@ -1,6 +1,6 @@
 package com.criteo.cuttle
 
-import java.time.Instant
+import java.time.{Instant, LocalDate}
 
 import scala.concurrent.duration._
 import scala.util._
@@ -55,6 +55,11 @@ private[cuttle] object App {
 
   implicit val instantEncoder = new Encoder[Instant] {
     override def apply(date: Instant) =
+      date.toString.asJson
+  }
+
+  implicit val dateEncoder = new Encoder[LocalDate] {
+    override def apply(date: LocalDate) =
       date.toString.asJson
   }
 

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -375,7 +375,7 @@ private[timeseries] trait TimeSeriesApp { self: TimeSeriesScheduler =>
                 if (completion == 0 && done != 0) 0.1
                 else completion
               Map(
-                "date" -> date.asJson,
+                "date" -> date.atZone(UTC).toLocalDate.asJson,
                 "completion" -> correctedCompletion.asJson
               ) ++ (if (stuck) Map("stuck" -> true.asJson) else Map.empty) ++
                 (if (backfillDomain.intersect(Interval(date, Daily(UTC).next(date))).toList.nonEmpty)


### PR DESCRIPTION
Fixes a calendar display bug that occurred in some timezones