### PR TITLE
[EXPERIMENTAL] slff4J & Log4J redirection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,6 +200,9 @@ lazy val cuttle =
         "mysql" % "mysql-connector-java" % "6.0.6"
       ),
       libraryDependencies ++= Seq(
+        "log4j" % "log4j" % "1.2.17" % "provided"
+      ),
+      libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % "3.0.1",
         "org.mockito" % "mockito-all" % "1.10.19",
         "org.tpolecat" %% "doobie-scalatest" % doobieVersion

--- a/core/src/main/scala/com/criteo/cuttle/ExecutionStreams.scala
+++ b/core/src/main/scala/com/criteo/cuttle/ExecutionStreams.scala
@@ -24,7 +24,7 @@ trait ExecutionStreams {
   /** Output debug messages (usually used by the [[ExecutionPlatform]]) */
   def debug(str: CharSequence = ""): Unit = this.writeln("DEBUG", str)
 
-  private def writeln(tag: String, str: CharSequence): Unit = {
+  private[cuttle] def writeln(tag: String, str: CharSequence): Unit = {
     val time = Instant.now.toString
     str.toString.split("\n").foreach(l => this.writeln(s"$time $tag - $l"))
   }

--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -2,6 +2,7 @@ package com.criteo.cuttle
 
 import java.io.{PrintWriter, StringWriter}
 import java.time.{Duration, Instant, ZoneId}
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{Timer, TimerTask}
 
@@ -349,6 +350,15 @@ private[cuttle] object ExecutionPlatform {
   implicit def fromExecution(implicit e: Execution[_]): Seq[ExecutionPlatform] = e.platforms
   def lookup[E: ClassTag](implicit platforms: Seq[ExecutionPlatform]): Option[E] =
     platforms.find(classTag[E].runtimeClass.isInstance).map(_.asInstanceOf[E])
+}
+
+private[cuttle] object Executor {
+
+  // we save a mapping of ThreadName -> ExecutionStreams to be able to redirect logs comming
+  // form different SideEffect (Futures) to the corresponding ExecutionStreams
+  private val threadNamesToStreams = new ConcurrentHashMap[String, ExecutionStreams]
+
+  def getStreams(threadName: String): Option[ExecutionStreams] = Option(threadNamesToStreams.get(threadName))
 }
 
 /** An [[Executor]] is responsible to actually execute the [[SideEffect]] functions for the
@@ -827,16 +837,33 @@ class Executor[S <: Scheduling] private[cuttle] (val platforms: Seq[ExecutionPla
                 .toLeft {
                   val nextExecutionId = utils.randomUUID
 
+                  val streams = new ExecutionStreams {
+                    def writeln(str: CharSequence) = ExecutionStreams.writeln(nextExecutionId, str)
+                  }
+
+                  // wrap the execution context so that we can register the name of the thread of each
+                  // runnable (and thus future) that will be run by the side effect.
+                  val sideEffectExecutionContext = SideEffectExecutionContext.wrap(runnable => new Runnable {
+                      override def run(): Unit = {
+                        val tName = Thread.currentThread().getName
+                        Executor.threadNamesToStreams.put(tName, streams)
+                        try {
+                          runnable.run()
+                        }
+                        finally {
+                          Executor.threadNamesToStreams.remove(tName)
+                        }
+                      }
+                    })(Implicits.sideEffectExecutionContext)
+
                   val execution = Execution(
                     id = nextExecutionId,
                     job,
                     context,
-                    streams = new ExecutionStreams {
-                      def writeln(str: CharSequence) = ExecutionStreams.writeln(nextExecutionId, str)
-                    },
+                    streams = streams,
                     platforms,
                     projectName
-                  )
+                  )(sideEffectExecutionContext)
                   val promise = Promise[Completed]
 
                   if (pausedState.contains(job.id)) {

--- a/core/src/main/scala/com/criteo/cuttle/log/ExecutionStreamsAppender.scala
+++ b/core/src/main/scala/com/criteo/cuttle/log/ExecutionStreamsAppender.scala
@@ -1,0 +1,43 @@
+package com.criteo.cuttle.log
+
+import com.criteo.cuttle.{ExecutionStreams, Executor}
+import org.apache.log4j.spi.LoggingEvent
+import org.apache.log4j.{AppenderSkeleton, Logger, Priority}
+
+class ExecutionStreamsAppender extends AppenderSkeleton {
+
+  override def append(event: LoggingEvent): Unit = {
+    val threadName = event.getThreadName
+    Executor.getStreams(threadName) match {
+      case Some(streams) => doAppend(event, streams)
+      case None =>
+    }
+  }
+
+  private def doAppend(event: LoggingEvent, streams: ExecutionStreams): Unit = {
+    val tag = event.getLevel.toInt match {
+      case Priority.DEBUG_INT => Some("DEBUG")
+      case Priority.ERROR_INT => Some("ERROR")
+      case Priority.FATAL_INT => Some("FATAL")
+      case Priority.WARN_INT => Some("WARN")
+      case Priority.INFO_INT => Some("INFO")
+      case _ => None
+    }
+    tag.foreach(streams.writeln(_, event.getRenderedMessage))
+  }
+
+  override def close(): Unit = {
+  }
+
+  override def requiresLayout(): Boolean = false
+}
+
+object ExecutionStreamsAppender {
+
+  private lazy val appender = new ExecutionStreamsAppender
+
+  // safe to call multiple time
+  def registerAsRootLogger(): Unit = {
+    Logger.getRootLogger.addAppender(appender)
+  }
+}

--- a/examples/src/main/scala/com/criteo/cuttle/examples/HelloWorldSLF4J.scala
+++ b/examples/src/main/scala/com/criteo/cuttle/examples/HelloWorldSLF4J.scala
@@ -1,0 +1,54 @@
+// Example: Hello cuttle SLF4J!
+
+// This examples shows how we can redirect slf4J and log4J logs to the execution stream by registering a
+// custom log appender that taps into the map of threads names to execution streams to redirect log events.
+package com.criteo.cuttle.examples
+
+import com.criteo.cuttle._
+import com.criteo.cuttle.log.ExecutionStreamsAppender
+import org.slf4j.LoggerFactory
+import scala.concurrent.Future
+import com.criteo.cuttle.timeseries._
+import java.time.ZoneOffset.UTC
+import java.time._
+
+import scala.concurrent.duration._
+
+object HelloWorldSLF4J {
+
+  // enable Log4J lo redirection to execution streams
+  ExecutionStreamsAppender.registerAsRootLogger()
+
+  // A logger for this class
+  private val log = LoggerFactory.getLogger(getClass)
+
+  def main(args: Array[String]): Unit = {
+
+    val start: Instant = LocalDate.now.minusDays(7).atStartOfDay.toInstant(UTC)
+    val hello1 =
+      Job("hello1", hourly(start), "Hello 1", tags = Set(Tag("hello"))) {
+        implicit e =>
+          val partitionToCompute = e.context.start + "-" + e.context.end
+
+          e.park(1.seconds) flatMap { _ =>
+          (Future {
+            log.info(s"A first future for Hello1")
+            Thread.sleep(5000)
+            log.info(s"Completed first future for Hello1")
+          } zip Future {
+            log.warn(s"A second, parallel future for Hello1")
+            Thread.sleep(5000)
+            log.warn(s"Completed second, parallel future for Hello1")
+          }) flatMap (_ => Future {
+            log.error(s"Final future for Hello1")
+            Thread.sleep(5000)
+            log.error(s"Completed final future for Hello1")
+            Completed
+          })
+        }
+      }
+
+    // Finally we bootstrap our cuttle project.
+    CuttleProject("Hello World", env = ("dev", false))(hello1).start()
+  }
+}


### PR DESCRIPTION
Slf4j and log4j are the standard for Java logging (eg: used by hadoop, hive, spark, ...). 
However when used from within Cuttle, these logs are not routed through the `ExecutionStreams`and thus not available in Cuttle's execution view, making it very hard to debug individual executions as these logs often end-up all mixed together in `stdout`.

This PR is a proof of concept on how we can wrap the `SideEffectExecutionContext` to register in a Map, each running thread (~future) of a side effect and the associated ExecutionStreams.
When a slf4j log event is then emitted by one of these thread, it is intecepted by a custom log4j appender, `ExecutionStreamsAppender`, which will then get the `ExecutionStreams` associated with the Thread which emitted this event and route the message through the streams. The event messages then become available in the Cuttle UI.

As show in `HelloWorldSLF4J`, this also works when multiple futures are running in parallel for a single side-effect.

This commit is not ready to be merged as it is, but is rather intended at being a proof of concept to allow further discussion on the subject.