### PR TITLE
Allow to properly copy-paste logs from StreamView

### DIFF
--- a/core/src/main/javascript/app/components/StreamView.js
+++ b/core/src/main/javascript/app/components/StreamView.js
@@ -70,9 +70,9 @@ class StreamView extends React.Component<Props, State> {
           return (
             <li key={i}>
               <span>{timestamp}</span>
-              <p className={props.classes[level]}>
+              <div className={props.classes[level]}>
                 {highlightURLs(message)}
-              </p>
+              </div>
             </li>
           );
         })}
@@ -123,10 +123,11 @@ const styles = {
       color: "#747a88",
       display: "inline-block",
       marginRight: "15px",
-      boxSizing: "border-box"
+      boxSizing: "border-box",
+      userSelect: "none"
     },
 
-    "& p": {
+    "& div": {
       display: "inline-block",
       margin: "0",
       color: "#f1f1f1",


### PR DESCRIPTION
This PR changes two things on the StreamView. component of the frontend app, to allow to copy-paste several lines of log properly;

- Puts the timestamps as user-select: none to disable the possibity to highlight it
- Changes the paragraph tag to a more general div one, to stop inserting newlines when selecting log lines and pasting them

I tested it on Firefox 61, Chrome 67 and Safari 11.1.1, on macOS 10.13.5.