### PR TITLE
Initialize job success/failure metrics at 0

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Metrics.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Metrics.scala
@@ -63,6 +63,12 @@ object Metrics {
       val currentCount = labels2Value.getOrElse(label, number.zero).asInstanceOf[T]
       copy(labels2Value = labels2Value + (label -> number.plus(currentCount, number.one).asInstanceOf[AnyVal]))
     }
+
+    def initialize(label: Set[(String, String)]): Counter[T] =
+      if (labels2Value.contains(label))
+        this
+      else
+        copy(labels2Value = labels2Value + (label -> number.zero.asInstanceOf[AnyVal]))
   }
 
   /** Components able to provide metrics. */


### PR DESCRIPTION
Without being initialized, the metric will start at 1 success and/or failure.
If using, e.g. increase() in prometheus, it will consder 1 to be the initial value and won't have a 0 before to measure an increase from.
This means silently disappearing lone failures on monitoring boards.