### PR TITLE
Optimize failure state retrieval in calendar view

### DIFF
--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -704,6 +704,7 @@ private[timeseries] case class TimeSeriesApp(project: CuttleProject, executor: E
           }
         val upToMidnightToday = Interval(Bottom, Finite(Daily(UTC).ceil(Instant.now)))
 
+        lazy val failingExecutionIds =  executor.allFailingExecutions.map(_.id).toSet
         val jobStatesOnPeriod: Set[JobStateOnPeriod] = for {
           job <- project.jobs.all
           if filteredJobs.contains(job.id)
@@ -717,7 +718,7 @@ private[timeseries] case class TimeSeriesApp(project: CuttleProject, executor: E
             case _ => false
           },
           jobState match {
-            case Running(exec) => executor.allFailingExecutions.exists(_.id == exec)
+            case Running(exec) => failingExecutionIds.contains(exec)
             case _             => false
           })
 


### PR DESCRIPTION
The current implementation used to do a linear scan of all the failing executions to check whether an execution failed or not, for each job and each execution period.