### PR TITLE
Move pause execution management inside scheduler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -209,6 +209,9 @@ lazy val cuttle =
 lazy val timeseries =
   (project in file("timeseries"))
     .settings(commonSettings: _*)
+    .settings(libraryDependencies ++= Seq(
+      "com.wix" % "wix-embedded-mysql" % "2.1.4" % "test"
+    ))
     .settings(
       // Webpack
       resourceGenerators in Compile += Def.task {

--- a/core/src/test/scala/com/criteo/cuttle/ExecutorSpec.scala
+++ b/core/src/test/scala/com/criteo/cuttle/ExecutorSpec.scala
@@ -43,7 +43,7 @@ class ExecutorSpec extends FunSuite with TestScheduling {
     val metrics = Prometheus.serialize(
       testExecutor.getMetrics(Set(fooJob))(
         getStateAtomic = _ => {
-          ((5, 1), 3, 2)
+          ((5, 1), 2)
         },
         runningExecutions = Seq(
           buildExecutionForJob(fooJob) -> ExecutionStatus.ExecutionRunning,
@@ -52,11 +52,6 @@ class ExecutorSpec extends FunSuite with TestScheduling {
           buildExecutionForJob(fooBarJob) -> ExecutionStatus.ExecutionRunning,
           buildExecutionForJob(untaggedJob) -> ExecutionStatus.ExecutionRunning,
           buildExecutionForJob(untaggedJob) -> ExecutionStatus.ExecutionWaiting
-        ),
-        pausedExecutions = Seq(
-          buildExecutionForJob(fooJob),
-          buildExecutionForJob(fooBarJob),
-          buildExecutionForJob(untaggedJob)
         ),
         failingExecutions = Seq(
           buildExecutionForJob(fooBarJob),
@@ -73,14 +68,11 @@ class ExecutorSpec extends FunSuite with TestScheduling {
          |# TYPE cuttle_scheduler_stat_count gauge
          |cuttle_scheduler_stat_count {type="running"} 5
          |cuttle_scheduler_stat_count {type="waiting"} 1
-         |cuttle_scheduler_stat_count {type="paused"} 3
          |cuttle_scheduler_stat_count {type="failing"} 2
          |# HELP cuttle_scheduler_stat_count_by_tag The number of executions that we have in concrete states by tag
          |# TYPE cuttle_scheduler_stat_count_by_tag gauge
-         |cuttle_scheduler_stat_count_by_tag {tag="bar", type="paused"} 1
          |cuttle_scheduler_stat_count_by_tag {tag="foo", type="waiting"} 1
          |cuttle_scheduler_stat_count_by_tag {tag="foo", type="running"} 3
-         |cuttle_scheduler_stat_count_by_tag {tag="foo", type="paused"} 2
          |cuttle_scheduler_stat_count_by_tag {tag="bar", type="failing"} 2
          |cuttle_scheduler_stat_count_by_tag {tag="foo", type="failing"} 2
          |cuttle_scheduler_stat_count_by_tag {tag="bar", type="running"} 1
@@ -90,12 +82,9 @@ class ExecutorSpec extends FunSuite with TestScheduling {
          |cuttle_scheduler_stat_count_by_job {job="foo_bar_job", type="running"} 1
          |cuttle_scheduler_stat_count_by_job {job="untagged_job", type="running"} 1
          |cuttle_scheduler_stat_count_by_job {job="foo_job", type="waiting"} 1
-         |cuttle_scheduler_stat_count_by_job {job="foo_job", type="paused"} 1
          |cuttle_scheduler_stat_count_by_job {job="untagged_job", type="failing"} 1
          |cuttle_scheduler_stat_count_by_job {job="foo_job", type="running"} 2
-         |cuttle_scheduler_stat_count_by_job {job="foo_bar_job", type="paused"} 1
          |cuttle_scheduler_stat_count_by_job {job="foo_bar_job", type="failing"} 2
-         |cuttle_scheduler_stat_count_by_job {job="untagged_job", type="paused"} 1
          |# HELP cuttle_executions_total The number of finished executions that we have in concrete states by job and by tag
          |# TYPE cuttle_executions_total counter
          |cuttle_executions_total {job_id="foo_job", tags="foo", type="failure"} 0

--- a/timeseries/src/main/javascript/app/menu/Menu.js
+++ b/timeseries/src/main/javascript/app/menu/Menu.js
@@ -70,12 +70,6 @@ const Menu = ({ classes, className, active, statistics }: Props) => (
           active={active.id === "executions/finished"}
           label="Finished"
           link="/executions/finished"
-        />,
-        <MenuSubEntry
-          active={active.id === "executions/paused"}
-          label="Paused"
-          link="/executions/paused"
-          badges={[statistics.paused && { label: statistics.paused }]}
         />
       ]}
     />

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/CuttleProject.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/CuttleProject.scala
@@ -41,7 +41,7 @@ class CuttleProject private[cuttle] (
 
     if (paused) {
       logger.info("Pausing workflow")
-      executor.pauseJobs(jobs.all)(Auth.User("Startup"))
+      scheduler.pauseJobs(jobs.all, executor, xa)(Auth.User("Startup"))
     }
 
     logger.info("Start workflow")

--- a/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSchedulerSpec.scala
+++ b/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSchedulerSpec.scala
@@ -1,0 +1,125 @@
+package com.criteo.cuttle.timeseries
+
+import java.time.ZoneOffset.UTC
+import java.time.{Duration, Instant, LocalDate}
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.Duration.Inf
+import scala.concurrent.{Await, Future}
+import scala.util.{Failure, Success}
+
+import com.wix.mysql._
+import com.wix.mysql.config.Charset._
+import com.wix.mysql.config._
+import com.wix.mysql.distribution.Version._
+
+import com.criteo.cuttle.platforms.local._
+import com.criteo.cuttle.timeseries.TimeSeriesUtils.{Run, TimeSeriesJob}
+import com.criteo.cuttle.{Auth, Database => CuttleDatabase, _}
+
+
+object TimeSeriesSchedulerSpec {
+  // TODO: turn this into a unit test. This is not done for now as the thread pool responsible for checking the lock on
+  // the state database creates non-daemon threads, which would result in the unit test not ending unless it is interrupted
+  // from the outside.
+  def main(args: Array[String]): Unit = {
+    val config = {
+      MysqldConfig.aMysqldConfig(v5_7_latest).withCharset(UTF8).withTimeout(3600, TimeUnit.SECONDS).withPort(3388).build()
+    }
+    val mysqld = EmbeddedMysql.anEmbeddedMysql(config).addSchema("cuttle_dev").start()
+
+    println("started!")
+    println("if needed you can connect to this running db using:")
+    println("> mysql -u root -h 127.0.0.1 -P 3388 cuttle_dev")
+
+    val project = CuttleProject("Hello World", version = "123", env = ("dev", false)) {
+      Jobs.childJob dependsOn Jobs.rootJob
+    }
+
+    val retryImmediatelyStrategy = new RetryStrategy {
+      def apply[S <: Scheduling](job: Job[S], context: S#Context, previouslyFailing: List[String]) =  Duration.ZERO
+      def retryWindow = Duration.ZERO
+    }
+
+    val xa = CuttleDatabase.connect(DatabaseConfig(Seq(DBLocation("127.0.0.1", 3388)), "cuttle_dev", "root", ""))
+    val executor = new Executor[TimeSeries](Seq(LocalPlatform(maxForkedProcesses = 10)), xa, logger, project.version)(retryImmediatelyStrategy)
+    val scheduler = project.scheduler
+
+    scheduler.initialize(project.jobs, xa, logger)
+
+    var runningExecutions = Set.empty[Run]
+
+    logger.info("Starting 'root-job' and 'child-job'")
+    runningExecutions = doSynchronousExecutionStep(scheduler, runningExecutions, project.jobs, executor, xa)
+    assert(runningExecutionsToJobIdAndResult(runningExecutions).equals(Set(("root-job", true))))
+
+    logger.info("'root-job' completed, the child job 'child-job' is triggered but fails")
+    runningExecutions = doSynchronousExecutionStep(scheduler, runningExecutions, project.jobs, executor, xa)
+    assert(runningExecutionsToJobIdAndResult(runningExecutions).equals(Set(("child-job", false))))
+
+    logger.info("'child-job' is paused")
+    val guestUser = Auth.User("Guest")
+    scheduler.pauseJobs(Set(Jobs.childJob), executor, xa)(guestUser)
+    assert((scheduler.pausedJobs().map { case PausedJob(jobId, user, date) => (jobId, user) }).equals(
+      Set(("child-job", guestUser))))
+    runningExecutions = doSynchronousExecutionStep(scheduler, runningExecutions, project.jobs, executor, xa)
+    assert(runningExecutions.isEmpty)
+
+    logger.info("'child-job' is resumed")
+    scheduler.resumeJobs(Set(Jobs.childJob), xa)(guestUser)
+    assert(scheduler.pausedJobs().isEmpty)
+    runningExecutions = doSynchronousExecutionStep(scheduler, runningExecutions, project.jobs, executor, xa)
+    assert(runningExecutionsToJobIdAndResult(runningExecutions).equals(Set(("child-job", true))))
+
+    logger.info("No more jobs to schedule for now")
+    runningExecutions = doSynchronousExecutionStep(scheduler, runningExecutions, project.jobs, executor, xa)
+    assert(runningExecutions.isEmpty)
+
+    mysqld.stop()
+  }
+
+  private def doSynchronousExecutionStep(scheduler: TimeSeriesScheduler,
+                                         runningExecutions: Set[Run],
+                                         workflow: Workflow,
+                                         executor: Executor[TimeSeries],
+                                         xa: XA): Set[(TimeSeriesJob, TimeSeriesContext, Future[Completed])] = {
+    val newRunningExecutions = scheduler.updateCurrentExecutionsAndSubmitNewExecutions(runningExecutions, workflow, executor, xa)
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val executionsResult = Future.sequence(newRunningExecutions.map { case (job, executionContext, futureResult) =>
+      logger.info(s"Executed ${job.id}")
+      futureResult
+    })
+    Await.ready(executionsResult, Inf)
+    newRunningExecutions
+  }
+
+  private def runningExecutionsToJobIdAndResult(runningExecutions: Set[Run]): Set[(String, Boolean)] = {
+    def executionResultToBoolean(result: Future[Completed]) = result.value match {
+      case Some(Success(_)) => true
+      case Some(Failure(t)) => false
+      case None => throw new Exception("The execution should have completed.")
+    }
+    runningExecutions.map { case (job, executionContext, futureResult) => (job.id, executionResultToBoolean(futureResult)) }
+  }
+
+  object Jobs {
+    private val start: Instant = LocalDate.now.minusDays(1).atStartOfDay.toInstant(UTC)
+
+    val rootJob = Job("root-job", daily(UTC, start)) { implicit e =>
+      Future(Completed)
+    }
+
+    private var failedOnce = false
+    // A job which fails the first time it runs
+    val childJob = Job("child-job", daily(UTC, start)) { implicit e =>
+      if (!failedOnce) {
+        failedOnce = true
+        throw new Exception("Always fails at the first execution")
+      }
+      else {
+        Future(Completed)
+      }
+    }
+  }
+}


### PR DESCRIPTION
No Execution instance is created when a job is paused.
On the UI side, the paused execution navigation menu was removed.