### PR TITLE
Makes JobState parsing more lenient

### DIFF
--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -302,10 +302,16 @@ private[timeseries] object JobState {
   case class Todo(maybeBackfill: Option[Backfill]) extends JobState
   case class Running(executionId: String) extends JobState
 
+  implicit val doneDecoder: Decoder[Done] = new Decoder[Done] {
+    final def apply(c: HCursor): Decoder.Result[Done] =
+      for {
+        version <- c.downField("projectVersion").as[String].orElse(Right("no-version"))
+      } yield Done(version)
+  }
+
   import TimeSeriesUtils._
   implicit val encoder: Encoder[JobState] = deriveEncoder
-  implicit def decoder(implicit jobs: Set[TimeSeriesJob]): Decoder[JobState] =
-    deriveDecoder
+  implicit def decoder(implicit jobs: Set[TimeSeriesJob]): Decoder[JobState] = deriveDecoder
   implicit val eqInstance: Eq[JobState] = Eq.fromUniversalEquals[JobState]
 }
 

--- a/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSpec.scala
+++ b/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSpec.scala
@@ -163,4 +163,44 @@ class TimeSeriesSpec extends FunSuite with TestScheduling {
       (date"2117-03-25T06:00:00Z", date"2117-03-25T07:00:00Z", Set(job1, job2))
     ))
   }
+
+  test("should parse JobState.Done without projectVersion") {
+    import io.circe.parser._
+
+    val state = """{
+      "Done": {}
+    }"""
+
+    val parseDone = parse(state).right.flatMap(json => json.as[JobState.Done])
+    assert(parseDone.isRight)
+    assert(parseDone.right.get == JobState.Done(projectVersion="no-version"))
+  }
+
+  test("should parse JobState without projectVersion") {
+    import io.circe.parser._
+
+    implicit val jobs: Set[Job[TimeSeries]] = Set.empty
+
+    val state = """{
+      "Done": {}
+    }"""
+
+    val parseState = parse(state).right.flatMap(json => json.as[JobState])
+    assert(parseState.isRight)
+    assert(parseState.right.get == JobState.Done(projectVersion="no-version"))
+  }
+
+  test("should parse JobState with projectVersion") {
+    import io.circe.parser._
+
+    implicit val jobs: Set[Job[TimeSeries]] = Set.empty
+
+    val state = """{
+      "Done": { "projectVersion" : "version" }
+    }"""
+
+    val parseState = parse(state).right.flatMap(_.as[JobState])
+    assert(parseState.isRight)
+    assert(parseState.right.get == JobState.Done(projectVersion="version"))
+  }
 }


### PR DESCRIPTION
Due to https://github.com/criteo/cuttle/pull/299, JobState.Done
parsing was not backwards compatible (field projectVersion introduced
in case class). The choice has been made here to assign a default
version instead of making it optional, in order to minimize bugfix
impact on the rest of the codebase.