### PR TITLE
Paused jobs remain paused at restart

### DIFF
--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -691,6 +691,7 @@ case class TimeSeriesScheduler(logger: Logger) extends Scheduler[TimeSeries] {
         .unsafeRunSync
 
       _backfills() = _backfills() ++ incompleteBackfills
+      _pausedJobs() = _pausedJobs() ++ queries.getPausedJobs.transact(xa).unsafeRunSync()
 
       workflow.vertices.foreach { job =>
         val calendar = job.scheduling.calendar


### PR DESCRIPTION
Fix a bug where after a deployment, all paused jobs were un-paused.