### PR TITLE
Fix the lastruns timeseries endpoint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val devMode = settingKey[Boolean]("Some build optimization are applied in devMode.")
 val writeClasspath = taskKey[File]("Write the project classpath to a file.")
 
-val VERSION = "0.4.5"
+val VERSION = "0.4.6"
 
 lazy val commonSettings = Seq(
   organization := "com.criteo.cuttle",

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -760,6 +760,8 @@ private[timeseries] case class TimeSeriesApp(project: CuttleProject, executor: E
           case Done(_) => true
           case _ => false
         }}
+        .foldLeft(IntervalMap.empty[Instant, Unit])((acc, elt) => acc.update(elt._1, ()))
+        .toList
 
       if (successfulIntervalMaps.isEmpty) NotFound
       else {


### PR DESCRIPTION
Since the version number has been added to the job states, we get
multiple intervals for each job and we can't use the fisrt we get anymore.
We merge all the intervals to retrieve their union and discard the version
in this case.