### PR TITLE
bumping lolhttp, cats, doobie. Removing cats-mtl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,12 @@
 val devMode = settingKey[Boolean]("Some build optimization are applied in devMode.")
 val writeClasspath = taskKey[File]("Write the project classpath to a file.")
 
-val VERSION = "0.4.7"
+val VERSION = "0.5.0"
+
+lazy val catsCore = "1.5.0"
+lazy val circe = "0.10.1"
+lazy val doobie = "0.6.0"
+lazy val lolhttp = "0.12.0"
 
 lazy val commonSettings = Seq(
   organization := "com.criteo.cuttle",
@@ -168,8 +173,6 @@ lazy val localdb = {
     )
 }
 
-val doobieVersion = "0.5.0"
-
 lazy val cuttle =
   (project in file("core"))
     .configs(IntegrationTest)
@@ -180,29 +183,26 @@ lazy val cuttle =
         "com.criteo.lolhttp" %% "lolhttp",
         "com.criteo.lolhttp" %% "loljson",
         "com.criteo.lolhttp" %% "lolhtml"
-      ).map(_ % "0.9.3"),
+      ).map(_ % lolhttp),
       libraryDependencies ++= Seq("core", "generic", "parser", "java8")
-        .map(module => "io.circe" %% s"circe-${module}" % "0.9.1"),
+        .map(module => "io.circe" %% s"circe-$module" % circe),
       libraryDependencies ++= Seq(
         "de.sciss" %% "fingertree" % "1.5.2",
         "org.scala-stm" %% "scala-stm" % "0.8",
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-        "org.typelevel" %% "cats-core" % "1.0.1",
-        "org.typelevel" %% "cats-mtl-core" % "0.2.3",
+        "org.typelevel" %% "cats-core" % catsCore,
         "codes.reactive" %% "scala-time" % "0.4.1",
-        "com.zaxxer" % "nuprocess" % "1.1.0"
+        "com.zaxxer" % "nuprocess" % "1.1.0",
+        "mysql" % "mysql-connector-java" % "6.0.6"
       ),
       libraryDependencies ++= Seq(
         "org.tpolecat" %% "doobie-core",
         "org.tpolecat" %% "doobie-hikari"
-      ).map(_ % doobieVersion),
-      libraryDependencies ++= Seq(
-        "mysql" % "mysql-connector-java" % "6.0.6"
-      ),
+      ).map(_ % doobie),
       libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % "3.0.1",
         "org.mockito" % "mockito-all" % "1.10.19",
-        "org.tpolecat" %% "doobie-scalatest" % doobieVersion
+        "org.tpolecat" %% "doobie-scalatest" % doobie
       ).map(_ % "it,test")
     )
 

--- a/core/src/it/scala/com/criteo/cuttle/DatabaseSuite.scala
+++ b/core/src/it/scala/com/criteo/cuttle/DatabaseSuite.scala
@@ -19,6 +19,7 @@ class DatabaseSuite extends FunSuite with BeforeAndAfter {
 
   // service transactor is used for schema creation
   private val serviceTransactor: doobie.Transactor[IO] = Database.newHikariTransactor(dbConfig)
+    .allocated.unsafeRunSync()._1
 
   private implicit val logHandler: log.LogHandler = DoobieLogsHandler(logger).handler
 

--- a/core/src/main/scala/com/criteo/cuttle/DoobieLogsHandler.scala
+++ b/core/src/main/scala/com/criteo/cuttle/DoobieLogsHandler.scala
@@ -6,7 +6,7 @@ case class DoobieLogsHandler(private val logger: Logger) {
   implicit val handler: LogHandler = LogHandler {
 
     case Success(s, a, e1, e2) =>
-      logger.info(s"""
+      logger.debug(s"""
                      | Successful Statement Execution:
                      |
                      | ${s.lines.dropWhile(_.trim.isEmpty).mkString("\n  ")}

--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -450,11 +450,8 @@ class Executor[S <: Scheduling] private[cuttle] (val platforms: Seq[ExecutionPla
     }
 
   private def startMonitoringExecutions() = {
-    val SC = utils.createScheduler("com.criteo.cuttle.platforms.ExecutionMonitor.SC")
-
     val intervalSeconds = 1
-    SC.awakeEvery[IO](intervalSeconds.second)
-      .map(_ => {
+    utils.awakeEvery(intervalSeconds.seconds).map(_ => {
         runningExecutions
           .filter({ case (_, s) => s == ExecutionStatus.ExecutionWaiting })
           .foreach({ case (e, _) => e.updateWaitingTime(intervalSeconds) })

--- a/core/src/test/scala/com/criteo/cuttle/ExecutorSpec.scala
+++ b/core/src/test/scala/com/criteo/cuttle/ExecutorSpec.scala
@@ -10,6 +10,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
 import com.criteo.cuttle.ThreadPools.Implicits.sideEffectThreadPool
+import com.criteo.cuttle.ThreadPools.Implicits.sideEffectContextShift
 import com.criteo.cuttle.ThreadPools._
 
 import com.criteo.cuttle.Metrics.Prometheus
@@ -28,7 +29,7 @@ class ExecutorSpec extends FunSuite with TestScheduling {
 
     val testExecutor = new Executor[TestScheduling](
       Seq.empty,
-      xa = Transactor.fromConnection[IO](connection).copy(strategy0 = doobie.util.transactor.Strategy.void),
+      xa = Transactor.fromConnection[IO](connection, sideEffectThreadPool).copy(strategy0 = doobie.util.transactor.Strategy.void),
       logger,
       "project_name",
       "test_version"

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -16,7 +16,6 @@ import scala.math.Ordering.Implicits._
 import cats._
 import cats.effect.IO
 import cats.implicits._
-import cats.mtl.implicits._
 import de.sciss.fingertree.RangedSeq
 import doobie._
 import doobie.implicits._

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/intervals/IntervalMap.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/intervals/IntervalMap.scala
@@ -1,19 +1,18 @@
 package com.criteo.cuttle.timeseries.intervals
 
 import scala.math.Ordered.orderingToOrdered
+
 import cats._
 import de.sciss.fingertree.{FingerTree, Measure}
 import FingerTree._
 import Bound.{Bottom, Top}
-import cats.mtl.FunctorEmpty
-import cats.mtl._
-import cats.mtl.implicits._
+import cats.FunctorFilter
+import cats.implicits._
 
 private[timeseries] object IntervalMap {
 
   private class MeasureKey[A, B] extends Measure[(A, B), Option[A]] {
     override def toString = "Key"
-
     val zero: Option[A] = None
     def apply(x: (A, B)) = Some(x._1)
 
@@ -143,7 +142,7 @@ private[timeseries] object IntervalMap {
     }
   }
 
-  implicit def functorEmptyInstance[K: Ordering] = new FunctorEmpty[({ type Alias[a] = IntervalMap[K, a] })#Alias] {
+  implicit def functorEmptyInstance[K: Ordering] = new FunctorFilter[({ type Alias[a] = IntervalMap[K, a] })#Alias] {
     override val functor = implicitly[Functor[({ type Alias[a] = IntervalMap[K, a] })#Alias]]
 
     override def mapFilter[A, B](fa: IntervalMap[K, A])(f: A => Option[B]) = fa match {


### PR DESCRIPTION
New version: 0.5.0

bumping FP libs:
  catsCore = "1.5.0"
  circe = "0.10.1"
  doobie = "0.6.0"
  lolhttp = "0.12.0"

- doobie Transactor is now a cats Resource and doesn't have a shutdown method, instead we use Resource.allocated and obtain an IO to release the Hikari Pool
- doobie now needs a dedicated thread pool and dedicated ContextShift
- now we log each Doobie query for debug purposes
- xmap of circe is deprecated => we should use imap
- fs2.Scheduler is replaced by cats.effect.IO.timer and now needs and implicit cats.effect.Timer in the scope
- cats-mtl was removed as FunctorFilter was moved to cats-core
- couple of logs were added