### PR TITLE
Cron scheduler api

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Database.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Database.scala
@@ -163,8 +163,6 @@ private[cuttle] object Database {
         """.update.run.transact(xa).unsafeRunSync
     })
 
-    // TODO, verify if it's in daemon mode
-
     // Refresh our lock every minute (and check that we still are the lock owner)
     ThreadPools
       .newScheduledThreadPool(1, poolName = Some("DatabaseLock"))

--- a/core/src/main/scala/com/criteo/cuttle/Database.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Database.scala
@@ -1,7 +1,7 @@
 package com.criteo.cuttle
 
 import java.time._
-import java.util.concurrent.{ExecutorService, TimeUnit}
+import java.util.concurrent.TimeUnit
 
 import scala.util._
 
@@ -13,7 +13,7 @@ import io.circe.syntax._
 import io.circe.parser._
 import cats.data.NonEmptyList
 import cats.implicits._
-import cats.effect.{IO, Resource, Sync}
+import cats.effect.{IO, Resource}
 import doobie.util.log
 
 import com.criteo.cuttle.ExecutionStatus._

--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -177,6 +177,12 @@ private[cuttle] case class PausedJob(id: String, user: User, date: Instant) {
     PausedJobWithExecutions(id, user, date, Map.empty[Execution[S], Promise[Completed]])
 }
 
+private[cuttle] object PausedJob {
+  import io.circe.generic.semiauto._
+  implicit val encodeUser: Encoder[User] = deriveEncoder
+  implicit val encodePausedJob: Encoder[PausedJob] = deriveEncoder
+}
+
 /** [[Execution Executions]] are created by the [[Scheduler]].
   *
   * @param id The unique id for this execution. Guaranteed to be unique.
@@ -459,7 +465,9 @@ class Executor[S <: Scheduling] private[cuttle] (val platforms: Seq[ExecutionPla
 
   private def startMonitoringExecutions() = {
     val intervalSeconds = 1
-    utils.awakeEvery(intervalSeconds.seconds).map(_ => {
+    utils
+      .awakeEvery(intervalSeconds.seconds)
+      .map(_ => {
         runningExecutions
           .filter({ case (_, s) => s == ExecutionStatus.ExecutionWaiting })
           .foreach({ case (e, _) => e.updateWaitingTime(intervalSeconds) })

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronApp.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronApp.scala
@@ -3,7 +3,7 @@ package com.criteo.cuttle.cron
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
-import scala.util.{Try, _}
+import scala.util.{Success, Try}
 
 import cats.data.EitherT
 import cats.effect.IO

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronApp.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronApp.scala
@@ -1,888 +1,152 @@
 package com.criteo.cuttle.cron
 
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
-import scala.util._
+import scala.util.{Try, _}
 
+import cats.data.EitherT
 import cats.effect.IO
-import cats.implicits._
-import com.criteo.cuttle.Auth._
-import com.criteo.cuttle.ExecutionStatus._
-import com.criteo.cuttle.Metrics.{Gauge, Prometheus}
-import com.criteo.cuttle._
-import com.criteo.cuttle.events.JobSuccessForced
-import com.criteo.cuttle.utils.getJVMUptime
-import doobie.implicits._
 import io.circe._
-import io.circe.generic.auto._
-import io.circe.java8.time._
 import io.circe.syntax._
 import lol.http._
 import lol.json._
 
-private[cron] case class CronApp() {
+import com.criteo.cuttle.Auth._
+import com.criteo.cuttle.Metrics.{Gauge, Prometheus}
+import com.criteo.cuttle._
+import com.criteo.cuttle.utils.getJVMUptime
 
-//  private val allIds = jobs.all.map(_.id)
-//
-//  private def parseJobIds(jobsQueryString: String): Set[String] =
-//    jobsQueryString.split(",").filter(_.trim().nonEmpty).toSet
-//
-//  private def getJobsOrNotFound(jobsQueryString: String): Either[Response, Set[Job[TimeSeries]]] = {
-//    val jobsNames = parseJobIds(jobsQueryString)
-//    if (jobsNames.isEmpty) Right(jobs.all)
-//    else {
-//      val filteredJobs = jobs.all.filter(v => jobsNames.contains(v.id))
-//      if (filteredJobs.isEmpty) Left(NotFound)
-//      else Right(filteredJobs)
-//    }
-//  }
+private[cron] case class CronApp(project: CronProject, executor: Executor[CronScheduling])(
+  implicit val transactor: XA) {
+  // Fair assumptions about start and end date within which we operate by default if user doesn't specify his interval.
+  // We choose these dates over Instant.MIN and Instant.MAX because MySQL works within this range.
+  private val minStartDateForExecutions = Instant.parse("1000-01-01T00:00:00Z")
+  private val maxStartDateForExecutions = Instant.parse("9999-12-31T23:59:59Z")
 
-//  val publicApi: PartialService = {
-//
-//    case GET at url"/api/status" => {
-//      val projectJson = (status: String) =>
-//        Json.obj(
-//          "project" -> project.name.asJson,
-//          "version" -> Option(project.version).filterNot(_.isEmpty).asJson,
-//          "status" -> status.asJson
-//      )
-//      executor.healthCheck() match {
-//        case Success(_) => Ok(projectJson("ok"))
-//        case _          => InternalServerError(projectJson("ko"))
-//      }
-//    }
-//
-//    case GET at url"/api/statistics?events=$events&jobs=$jobs" =>
-//      val jobIds = parseJobIds(jobs)
-//      val ids = if (jobIds.isEmpty) allIds else jobIds
-//
-//      def getStats: IO[Option[(Json, Json)]] =
-//        executor
-//          .getStats(ids)
-//          .map(
-//            stats =>
-//              Try(
-//                stats -> scheduler.getStats(ids)
-//              ).toOption)
-//
-//      def asJson(x: (Json, Json)) = x match {
-//        case (executorStats, schedulerStats) =>
-//          executorStats.deepMerge(
-//            Json.obj(
-//              "scheduler" -> schedulerStats
-//            ))
-//      }
-//
-//      events match {
-//        case "true" | "yes" =>
-//          sse(IO.suspend(getStats), (x: (Json, Json)) => IO(asJson(x)))
-//        case _ => getStats.map(_.map(stat => Ok(asJson(stat))).getOrElse(InternalServerError))
-//      }
-//
-//    case GET at url"/api/statistics/$jobName" =>
-//      executor
-//        .jobStatsForLastThirtyDays(jobName)
-//        .map(stats => Ok(stats.asJson))
-//
-//    case GET at url"/version" => Ok(project.version)
-//
-//    case GET at "/metrics" =>
-//      val metrics =
-//        executor.getMetrics(allIds, jobs) ++
-//          scheduler.getMetrics(allIds, jobs) :+
-//          Gauge("cuttle_jvm_uptime_seconds").labeled(("version", project.version), getJVMUptime)
-//      Ok(Prometheus.serialize(metrics))
-//
-//    case GET at url"/api/executions/status/$kind?limit=$l&offset=$o&events=$events&sort=$sort&order=$order&jobs=$jobs" =>
-//      logger.debug(s"Retreiving $kind executions with sse mode $events")
-//      val jobIds = parseJobIds(jobs)
-//      val limit = Try(l.toInt).toOption.getOrElse(25)
-//      val offset = Try(o.toInt).toOption.getOrElse(0)
-//      val asc = order.toLowerCase == "asc"
-//      val ids = if (jobIds.isEmpty) allIds else jobIds
-//
-//      def getExecutions: IO[Option[(Int, List[ExecutionLog])]] = kind match {
-//        case "started" =>
-//          IO(
-//            Some(
-//              executor.runningExecutionsSizeTotal(ids) -> executor
-//                .runningExecutions(ids, sort, asc, offset, limit)
-//                .toList))
-//        case "stuck" =>
-//          IO(
-//            Some(
-//              executor.failingExecutionsSize(ids) -> executor
-//                .failingExecutions(ids, sort, asc, offset, limit)
-//                .toList))
-//        case "finished" =>
-//          executor
-//            .archivedExecutionsSize(ids)
-//            .map(ids => Some(ids -> executor.allRunning.toList))
-//        case _ =>
-//          IO.pure(None)
-//      }
-//
-//      def asJson(x: (Int, Seq[ExecutionLog])): IO[Json] = x match {
-//        case (total, executions) =>
-//          (kind match {
-//            case "finished" =>
-//              executor
-//                .archivedExecutions(scheduler.allContexts, ids, sort, asc, offset, limit, xa)
-//                .map(execs => execs.asJson)
-//            case _ =>
-//              IO(executions.asJson)
-//          }).map(
-//            data =>
-//              Json.obj(
-//                "total" -> total.asJson,
-//                "offset" -> offset.asJson,
-//                "limit" -> limit.asJson,
-//                "sort" -> sort.asJson,
-//                "asc" -> asc.asJson,
-//                "data" -> data
-//            ))
-//      }
-//
-//      events match {
-//        case "true" | "yes" =>
-//          sse(getExecutions, asJson)
-//        case _ =>
-//          getExecutions
-//            .flatMap(
-//              _.map(e => asJson(e).map(json => Ok(json)))
-//                .getOrElse(NotFound))
-//      }
-//
-//    case GET at url"/api/executions/$id?events=$events" =>
-//      def getExecution = IO.suspend(executor.getExecution(scheduler.allContexts, id))
-//
-//      events match {
-//        case "true" | "yes" =>
-//          sse(getExecution, (e: ExecutionLog) => IO(e.asJson))
-//        case _ =>
-//          getExecution.map(_.map(e => Ok(e.asJson)).getOrElse(NotFound))
-//      }
-//
-//    case req @ GET at url"/api/executions/$id/streams" =>
-//      lazy val streams = executor.openStreams(id)
-//      req.headers.get(h"Accept").contains(h"text/event-stream") match {
-//        case true =>
-//          Ok(
-//            fs2.Stream(ServerSentEvents.Event("BOS".asJson)) ++
-//              streams
-//                .through(fs2.text.utf8Decode)
-//                .through(fs2.text.lines)
-//                .chunks
-//                .map(chunk => ServerSentEvents.Event(Json.fromValues(chunk.toArray.toIterable.map(_.asJson)))) ++
-//              fs2.Stream(ServerSentEvents.Event("EOS".asJson))
-//          )
-//        case false =>
-//          Ok(
-//            Content(
-//              stream = streams,
-//              headers = Map(h"Content-Type" -> h"text/plain")
-//            ))
-//      }
-//
-//    case GET at "/api/jobs/paused" =>
-//      Ok(scheduler.pausedJobs().asJson)
-//
-//    case GET at "/api/project_definition" =>
-//      Ok(project.asJson)
-//
-//    case GET at "/api/jobs_definition" =>
-//      Ok(jobs.asJson)
-//  }
+  private val scheduler = project.scheduler
+  private val workload = project.workload
 
-//  val privateApi: AuthenticatedService = {
-//    case POST at url"/api/executions/$id/cancel" => { implicit user =>
-//      executor.cancelExecution(id)
-//      Ok
-//    }
-//
-//    case POST at url"/api/jobs/pause?jobs=$jobs" => { implicit user =>
-//      getJobsOrNotFound(jobs).fold(IO.pure, jobs => {
-//        scheduler.pauseJobs(jobs, executor, xa)
-//        Ok
-//      })
-//    }
-//
-//    case POST at url"/api/jobs/resume?jobs=$jobs" => { implicit user =>
-//      getJobsOrNotFound(jobs).fold(IO.pure, jobs => {
-//        scheduler.resumeJobs(jobs, xa)
-//        Ok
-//      })
-//    }
-//    case POST at url"/api/jobs/all/unpause" => { implicit user =>
-//      scheduler.resumeJobs(jobs.all, xa)
-//      Ok
-//    }
-//    case POST at url"/api/jobs/$id/unpause" => { implicit user =>
-//      jobs.all.find(_.id == id).fold(NotFound) { job =>
-//        scheduler.resumeJobs(Set(job), xa)
-//        Ok
-//      }
-//    }
-//    case POST at url"/api/executions/relaunch?jobs=$jobs" => { implicit user =>
-//      val filteredJobs = Try(jobs.split(",").toSeq.filter(_.nonEmpty)).toOption
-//        .filter(_.nonEmpty)
-//        .getOrElse(allIds)
-//        .toSet
-//
-//      executor.relaunch(filteredJobs)
-//      IO.pure(Ok)
-//    }
-//
-//    case req @ GET at url"/api/shutdown" => { implicit user =>
-//      import scala.concurrent.duration._
-//
-//      req.queryStringParameters.get("gracePeriodSeconds") match {
-//        case Some(s) =>
-//          Try(s.toLong) match {
-//            case Success(s) if s > 0 =>
-//              executor.gracefulShutdown(Duration(s, TimeUnit.SECONDS))
-//              Ok
-//            case _ =>
-//              BadRequest("gracePeriodSeconds should be a positive integer")
-//          }
-//        case None =>
-//          req.queryStringParameters.get("hard") match {
-//            case Some(_) =>
-//              executor.hardShutdown()
-//              Ok
-//            case None =>
-//              BadRequest("Either gracePeriodSeconds or hard should be specified as query parameter")
-//          }
-//      }
-//    }
-//  }
-//
-//  private implicit val intervalEncoder = new Encoder[Interval[Instant]] {
-//    implicit val boundEncoder = new Encoder[Bound[Instant]] {
-//      override def apply(bound: Bound[Instant]) = bound match {
-//        case Bottom    => "-oo".asJson
-//        case Top       => "+oo".asJson
-//        case Finite(t) => t.asJson
-//      }
-//    }
-//
-//    override def apply(interval: Interval[Instant]) =
-//      Json.obj(
-//        "start" -> interval.lo.asJson,
-//        "end" -> interval.hi.asJson
-//      )
-//  }
-//  private val queries = new Queries {}
+  private val allJobIds = workload.all.map(_.id)
 
-//  private trait ExecutionPeriod {
-//    val period: Interval[Instant]
-//    val backfill: Boolean
-//    val aggregated: Boolean
-//    val version: String
-//  }
+  val publicApi: PartialService = {
+    case GET at "/version" => Ok(project.version)
 
-//  private case class JobExecution(period: Interval[Instant], status: String, backfill: Boolean, version: String)
-//      extends ExecutionPeriod {
-//    override val aggregated: Boolean = false
-//  }
+    case GET at "/metrics" =>
+      val metrics =
+        executor.getMetrics(allJobIds, workload) ++
+          scheduler.getMetrics(allJobIds, workload) :+
+          Gauge("cuttle_jvm_uptime_seconds").labeled(("version", project.version), getJVMUptime)
 
-//  private case class AggregatedJobExecution(period: Interval[Instant],
-//                                            completion: Double,
-//                                            error: Boolean,
-//                                            backfill: Boolean,
-//                                            version: String = "")
-//      extends ExecutionPeriod {
-//    override val aggregated: Boolean = true
-//  }
+      Ok(Prometheus.serialize(metrics))
 
-//  private case class JobTimeline(jobId: String, calendarView: TimeSeriesCalendarView, executions: List[ExecutionPeriod])
+    case GET at "/api/status" =>
+      val projectJson = (status: String) =>
+        Json.obj(
+          "project" -> project.name.asJson,
+          "version" -> Option(project.version).filterNot(_.isEmpty).asJson,
+          "status" -> status.asJson
+      )
+      executor.healthCheck() match {
+        case Success(_) => Ok(projectJson("ok"))
+        case _          => InternalServerError(projectJson("ko"))
+      }
 
-//  private implicit val executionPeriodEncoder = new Encoder[ExecutionPeriod] {
-//    override def apply(executionPeriod: ExecutionPeriod) = {
-//      val coreFields = List(
-//        "period" -> executionPeriod.period.asJson,
-//        "backfill" -> executionPeriod.backfill.asJson,
-//        "aggregated" -> executionPeriod.aggregated.asJson,
-//        "version" -> executionPeriod.version.asJson
-//      )
-//      val finalFields = executionPeriod match {
-//        case JobExecution(_, status, _, _) => ("status" -> status.asJson) :: coreFields
-//        case AggregatedJobExecution(_, completion, error, _, _) =>
-//          ("completion" -> completion.asJson) :: ("error" -> error.asJson) :: coreFields
-//      }
-//      Json.obj(finalFields: _*)
-//    }
-//  }
+    case GET at "/api/project_definition" => Ok(project.asJson)
 
-//  private implicit val jobTimelineEncoder = new Encoder[JobTimeline] {
-//    override def apply(jobTimeline: JobTimeline) = jobTimeline.executions.asJson
-//  }
+    case GET at "/api/jobs_definition" => Ok(workload.asJson)
 
-//  case class ExecutionDetails(jobExecutions: Seq[ExecutionLog], parentExecutions: Seq[ExecutionLog])
+    case req @ GET at url"/api/executions/$id/streams" =>
+      lazy val streams = executor.openStreams(id)
+      req.headers.get(h"Accept").contains(h"text/event-stream") match {
+        case true =>
+          val stream = fs2.Stream(ServerSentEvents.Event("BOS".asJson)) ++ streams
+            .through(fs2.text.utf8Decode)
+            .through(fs2.text.lines)
+            .chunks
+            .map(chunk => ServerSentEvents.Event(Json.fromValues(chunk.toArray.toIterable.map(_.asJson)))) ++
+            fs2.Stream(ServerSentEvents.Event("EOS".asJson))
+          Ok(stream)
+        case false =>
+          val bodyFromStream = Content(
+            stream = streams,
+            headers = Map(h"Content-Type" -> h"text/plain")
+          )
+          Ok(bodyFromStream)
+      }
 
-//  private implicit val executionDetailsEncoder: Encoder[ExecutionDetails] =
-//    Encoder.forProduct2("jobExecutions", "parentExecutions")(
-//      e => (e.jobExecutions, e.parentExecutions)
-//    )
+    case GET at "/api/dashboard" =>
+      Ok(scheduler.getStats(allJobIds))
 
-//  private[timeseries] def publicRoutes(): PartialService = {
-//    case request @ GET at url"/api/timeseries/executions?job=$jobId&start=$start&end=$end" =>
-//      type WatchedState = ((State, Set[Backfill]), Set[(Job[TimeSeries], TimeSeriesContext)])
-//
-//      def watchState(): Option[WatchedState] = Some((scheduler.state, executor.allFailingJobsWithContext))
-//
-//      def getExecutions(watchedState: WatchedState): IO[Json] = {
-//        val job = jobs.vertices.find(_.id == jobId).get
-//        val calendar = job.scheduling.calendar
-//        val startDate = Instant.parse(start)
-//        val endDate = Instant.parse(end)
-//        val requestedInterval = Interval(startDate, endDate)
-//        val contextQuery = Database.sqlGetContextsBetween(Some(startDate), Some(endDate))
-//        val archivedExecutions =
-//          executor.archivedExecutions(contextQuery, Set(jobId), "", asc = true, 0, Int.MaxValue, xa)
-//        val runningExecutions = executor.runningExecutions
-//          .filter {
-//            case (e, _) =>
-//              e.job.id == jobId && e.context.toInterval.intersects(requestedInterval)
-//          }
-//          .map { case (e, status) => e.toExecutionLog(status) }
-//
-//        val ((jobStates, _), _) = watchedState
-//        val remainingExecutions =
-//          for {
-//            (interval, maybeBackfill) <- jobStates(job)
-//              .intersect(requestedInterval)
-//              .toList
-//              .collect { case (itvl, Todo(maybeBackfill)) => (itvl, maybeBackfill) }
-//            (lo, hi) <- calendar.split(interval)
-//          } yield {
-//            val context =
-//              TimeSeriesContext(calendar.truncate(lo), calendar.ceil(hi), maybeBackfill, executor.projectVersion)
-//            ExecutionLog("", job.id, None, None, context.asJson, ExecutionTodo, None, 0)
-//          }
-//        val throttledExecutions = executor.allFailingExecutions
-//          .filter(e => e.job == job && e.context.toInterval.intersects(requestedInterval))
-//          .map(_.toExecutionLog(ExecutionThrottled))
-//
-//        archivedExecutions.map(
-//          archivedExecutions =>
-//            ExecutionDetails(archivedExecutions ++ runningExecutions ++ remainingExecutions ++ throttledExecutions,
-//                             parentExecutions(requestedInterval, job, jobStates)).asJson)
-//      }
-//
-//      def parentExecutions(requestedInterval: Interval[Instant],
-//                           job: Job[TimeSeries],
-//                           state: Map[Job[TimeSeries], IntervalMap[Instant, JobState]]): Seq[ExecutionLog] = {
-//
-//        val calendar = job.scheduling.calendar
-//        val parentJobs = jobs.edges
-//          .collect({ case (child, parent, _) if child == job => parent })
-//        val runningDependencies: Seq[ExecutionLog] = executor.runningExecutions
-//          .filter {
-//            case (e, _) => parentJobs.contains(e.job) && e.context.toInterval.intersects(requestedInterval)
-//          }
-//          .map({ case (e, status) => e.toExecutionLog(status) })
-//        val failingDependencies: Seq[ExecutionLog] = executor.allFailingExecutions
-//          .filter(e => parentJobs.contains(e.job) && e.context.toInterval.intersects(requestedInterval))
-//          .map(_.toExecutionLog(ExecutionThrottled))
-//        val remainingDependenciesDeps =
-//          for {
-//            parentJob <- parentJobs
-//            (interval, maybeBackfill) <- state(parentJob)
-//              .intersect(requestedInterval)
-//              .toList
-//              .collect { case (itvl, Todo(maybeBackfill)) => (itvl, maybeBackfill) }
-//            (lo, hi) <- calendar.split(interval)
-//          } yield {
-//            val context =
-//              TimeSeriesContext(calendar.truncate(lo), calendar.ceil(hi), maybeBackfill, executor.projectVersion)
-//            ExecutionLog("", parentJob.id, None, None, context.asJson, ExecutionTodo, None, 0)
-//          }
-//
-//        runningDependencies ++ failingDependencies ++ remainingDependenciesDeps.toSeq
-//      }
-//
-//      watchState() match {
-//        case Some(watchedState) =>
-//          if (request.headers.get(h"Accept").contains(h"text/event-stream"))
-//            sse(IO { Some(watchedState) }, (s: WatchedState) => getExecutions(s))
-//          else
-//            getExecutions(watchedState).map(Ok(_))
-//        case None =>
-//          BadRequest
-//      }
-//
-//    case request @ GET at url"/api/timeseries/calendar/focus?start=$start&end=$end&jobs=$jobs" =>
-//      type WatchedState = ((State, Set[Backfill]), Set[(Job[TimeSeries], TimeSeriesContext)])
-//
-//      val filteredJobs = Try(jobs.split(",").toSeq.filter(_.nonEmpty)).toOption
-//        .filter(_.nonEmpty)
-//        .getOrElse(project.jobs.all.map(_.id))
-//        .toSet
-//
-//      def watchState(): Option[WatchedState] = Some((scheduler.state, executor.allFailingJobsWithContext))
-//
-//      def getFocusView(watchedState: WatchedState) = {
-//        val startDate = Instant.parse(start)
-//        val endDate = Instant.parse(end)
-//        val period = Interval(startDate, endDate)
-//        val ((jobStates, backfills), _) = watchedState
-//        val backfillDomain =
-//          backfills.foldLeft(IntervalMap.empty[Instant, Unit]) { (acc, bf) =>
-//            if (bf.jobs.map(_.id).intersect(filteredJobs).nonEmpty)
-//              acc.update(Interval(bf.start, bf.end), ())
-//            else
-//              acc
-//          }
-//
-//        val pausedJobs = scheduler.pausedJobs().map(_.id)
-//        val allFailingExecutionIds = executor.allFailingExecutions.map(_.id).toSet
-//        val allWaitingExecutionIds = executor.allRunning
-//          .filter(_.status == ExecutionWaiting)
-//          .map(_.id)
-//          .toSet
-//
-//        def findAggregationLevel(n: Int,
-//                                 calendarView: TimeSeriesCalendarView,
-//                                 interval: Interval[Instant]): TimeSeriesCalendarView = {
-//          val aggregatedExecutions = calendarView.calendar.split(interval)
-//          if (aggregatedExecutions.size <= n)
-//            calendarView
-//          else
-//            findAggregationLevel(n, calendarView.upper(), interval)
-//        }
-//
-//        def aggregateExecutions(
-//          job: TimeSeriesJob,
-//          period: Interval[Instant],
-//          calendarView: TimeSeriesCalendarView): List[(Interval[Instant], List[(Interval[Instant], JobState)])] =
-//          calendarView.calendar
-//            .split(period)
-//            .flatMap { interval =>
-//              {
-//                val (start, end) = interval
-//                val currentlyAggregatedPeriod = jobStates(job)
-//                  .intersect(Interval(start, end))
-//                  .toList
-//                  .sortBy(_._1.lo)
-//                currentlyAggregatedPeriod match {
-//                  case Nil => None
-//                  case _   => Some((Interval(start, end), currentlyAggregatedPeriod))
-//                }
-//              }
-//            }
-//
-//        def getVersionFromState(jobState: JobState): String = jobState match {
-//          case Done(version) => version
-//          case _             => ""
-//        }
-//
-//        def getStatusLabelFromState(jobState: JobState, job: Job[TimeSeries]): String =
-//          jobState match {
-//            case Running(executionId) =>
-//              if (allFailingExecutionIds.contains(executionId))
-//                "failed"
-//              else if (allWaitingExecutionIds.contains(executionId))
-//                "waiting"
-//              else if (pausedJobs.contains(job.id))
-//                "paused"
-//              else "running"
-//            case Todo(_) => if (pausedJobs.contains(job.id)) "paused" else "todo"
-//            case Done(_) => "successful"
-//          }
-//
-//        val jobTimelines =
-//          (for { job <- project.jobs.all if filteredJobs.contains(job.id) } yield {
-//            val calendarView = findAggregationLevel(
-//              48,
-//              TimeSeriesCalendarView(job.scheduling.calendar),
-//              period
-//            )
-//            val jobExecutions: List[Option[ExecutionPeriod]] = for {
-//              (interval, jobStatesOnIntervals) <- aggregateExecutions(job, period, calendarView)
-//            } yield {
-//              val inBackfill = backfills.exists(
-//                bf =>
-//                  bf.jobs.contains(job) &&
-//                    IntervalMap(interval -> 0)
-//                      .intersect(Interval(bf.start, bf.end))
-//                      .toList
-//                      .nonEmpty)
-//              if (calendarView.aggregationFactor == 1) {
-//                jobStatesOnIntervals match {
-//                  case (_, state) :: Nil =>
-//                    Some(JobExecution(interval, getStatusLabelFromState(state, job), inBackfill, getVersionFromState(state)))
-//                  case _ => None
-//                }
-//              }
-//              else {
-//                jobStatesOnIntervals match {
-//                  case jobStates: List[(Interval[Instant], JobState)] if jobStates.nonEmpty => {
-//                    val (duration, done, error) = jobStates.foldLeft((0L, 0L, false)) {
-//                      case ((accumulatedDuration, accumulatedDoneDuration, hasErrors), (period, jobState)) =>
-//                        val (lo, hi) = period.toPair
-//                        val jobStatus = getStatusLabelFromState(jobState, job)
-//                        (accumulatedDuration + lo.until(hi, ChronoUnit.SECONDS),
-//                         accumulatedDoneDuration + (if (jobStatus == "successful") lo.until(hi, ChronoUnit.SECONDS) else 0),
-//                         hasErrors || jobStatus == "failed")
-//                    }
-//                    Some(AggregatedJobExecution(interval, done.toDouble / duration.toDouble, error, inBackfill))
-//                  }
-//                  case Nil => None
-//                }
-//              }
-//            }
-//            JobTimeline(job.id, calendarView, jobExecutions.flatten)
-//          }).toList
-//
-//        Json.obj(
-//          "summary" -> jobTimelines
-//            .maxBy(_.executions.size)
-//            .calendarView
-//            .calendar
-//            .split(period)
-//            .flatMap {
-//              case (lo, hi) =>
-//                val isInbackfill = backfillDomain.intersect(Interval(lo, hi)).toList.nonEmpty
-//
-//              case class JobSummary(periodLengthInSeconds: Long, periodDoneInSeconds: Long, hasErrors: Boolean)
-//
-//                val jobSummaries: Set[JobSummary] = for {
-//                  job <- project.jobs.all
-//                  if filteredJobs.contains(job.id)
-//                  (interval, jobState) <- jobStates(job).intersect(Interval(lo, hi)).toList
-//                } yield {
-//                  val (lo, hi) = interval.toPair
-//                  JobSummary(
-//                    periodLengthInSeconds = lo.until(hi, ChronoUnit.SECONDS),
-//                    periodDoneInSeconds = jobState match {
-//                      case Done(_) => lo.until(hi, ChronoUnit.SECONDS)
-//                      case _       => 0
-//                    },
-//                    hasErrors = jobState match {
-//                      case Running(executionId) => allFailingExecutionIds.contains(executionId)
-//                      case _          => false
-//                    })
-//                }
-//                if (jobSummaries.nonEmpty) {
-//                  val aggregatedJobSummary = jobSummaries.reduce { (a: JobSummary, b: JobSummary) =>
-//                    JobSummary(a.periodLengthInSeconds + b.periodLengthInSeconds,
-//                               a.periodDoneInSeconds + b.periodDoneInSeconds,
-//                               a.hasErrors || b.hasErrors)
-//                  }
-//                  Some(
-//                    AggregatedJobExecution(
-//                      Interval(lo, hi),
-//                      aggregatedJobSummary.periodDoneInSeconds.toDouble / aggregatedJobSummary.periodLengthInSeconds.toDouble,
-//                      aggregatedJobSummary.hasErrors, isInbackfill
-//                    )
-//                  )
-//                } else {
-//                  None
-//                }
-//            }
-//            .asJson,
-//          "jobs" -> jobTimelines.map(jt => jt.jobId -> jt).toMap.asJson
-//        )
-//      }
-//
-//      if (request.headers.get(h"Accept").contains(h"text/event-stream"))
-//        sse(IO { watchState() }, (s: WatchedState) => IO(getFocusView(s)))
-//      else
-//        watchState() match {
-//          case Some(watchedState) => Ok(getFocusView(watchedState))
-//          case None               => BadRequest
-//        }
-//
-//    case request @ GET at url"/api/timeseries/calendar?jobs=$jobs" =>
-//      val filteredJobs = Try(jobs.split(",").toSeq.filter(_.nonEmpty)).toOption
-//        .filter(_.nonEmpty)
-//        .getOrElse(project.jobs.all.map(_.id))
-//        .toSet
-//
-//      type WatchedState = ((TimeSeriesUtils.State, Set[Backfill]), Set[(Job[TimeSeries], TimeSeries#Context)])
-//
-//      case class JobStateOnPeriod(start: Instant, duration: Long, isDone: Boolean, isStuck: Boolean)
-//
-//      def watchState(): Option[WatchedState] = Some((scheduler.state, executor.allFailingJobsWithContext))
-//
-//      def getCalendar(watchedState: WatchedState): Json = {
-//        val ((jobStates, backfills), _) = watchedState
-//        val backfillDomain =
-//          backfills.foldLeft(IntervalMap.empty[Instant, Unit]) { (acc, bf) =>
-//            if (bf.jobs.map(_.id).intersect(filteredJobs).nonEmpty)
-//              acc.update(Interval(bf.start, bf.end), ())
-//            else
-//              acc
-//          }
-//        val upToMidnightToday = Interval(Bottom, Finite(Daily(UTC).ceil(Instant.now)))
-//
-//        lazy val failingExecutionIds = executor.allFailingExecutions.map(_.id).toSet
-//        val jobStatesOnPeriod: Set[JobStateOnPeriod] = for {
-//          job <- project.jobs.all
-//          if filteredJobs.contains(job.id)
-//          (interval, jobState) <- jobStates(job).intersect(upToMidnightToday).toList
-//          (start, end) <- Daily(UTC).split(interval)
-//        } yield
-//          JobStateOnPeriod(
-//            Daily(UTC).truncate(start),
-//            start.until(end, ChronoUnit.SECONDS),
-//            jobState match {
-//              case Done(_) => true
-//              case _       => false
-//            },
-//            jobState match {
-//              case Running(exec) => failingExecutionIds.contains(exec)
-//              case _             => false
-//            }
-//          )
-//
-//        jobStatesOnPeriod
-//          .groupBy { case JobStateOnPeriod(start, _, _, _) => start }
-//          .toList
-//          .sortBy { case (periodStart, _) => periodStart }
-//          .map {
-//            case (date, statesOnPeriod) =>
-//              val (total, done, stuck) = statesOnPeriod.foldLeft((0L, 0L, false)) {
-//                case (acc, JobStateOnPeriod(_, duration, isDone, isStuck)) =>
-//                  val (totalDuration, doneDuration, isAnyStuck) = acc
-//                  val newDone = if (isDone) duration else 0L
-//                  (totalDuration + duration, doneDuration + newDone, isAnyStuck || isStuck)
-//              }
-//              val completion = Math.floor((done.toDouble / total.toDouble) * 10) / 10
-//              val correctedCompletion =
-//                if (completion == 0 && done != 0) 0.1
-//                else completion
-//              Map(
-//                "date" -> date.atZone(UTC).toLocalDate.asJson,
-//                "completion" -> correctedCompletion.asJson
-//              ) ++ (if (stuck) Map("stuck" -> true.asJson) else Map.empty) ++
-//                (if (backfillDomain.intersect(Interval(date, Daily(UTC).next(date))).toList.nonEmpty)
-//                   Map("backfill" -> true.asJson)
-//                 else Map.empty)
-//          }
-//          .asJson
-//
-//      }
-//
-//      if (request.headers.get(h"Accept").contains(h"text/event-stream"))
-//        sse(IO { watchState() }, (s: WatchedState) => IO.pure(getCalendar(s)))
-//      else
-//        watchState() match {
-//          case Some(watchedState) => Ok(getCalendar(watchedState))
-//          case None               => BadRequest
-//        }
-//
-//    case GET at url"/api/timeseries/lastruns?job=$jobId" =>
-//      val (jobStates, _) = scheduler.state
-//      val successfulIntervalMaps = jobStates
-//        .filter(s => s._1.id == jobId)
-//        .values
-//        .flatMap(m => m.toList)
-//        .filter {
-//          case (interval, jobState) =>
-//            jobState match {
-//              case Done(_) => true
-//              case _       => false
-//            }
-//        }
-//        .foldLeft(IntervalMap.empty[Instant, Unit])((acc, elt) => acc.update(elt._1, ()))
-//        .toList
-//
-//      if (successfulIntervalMaps.isEmpty) NotFound
-//      else {
-//        (successfulIntervalMaps.head._1.hi, successfulIntervalMaps.last._1.hi) match {
-//          case (Finite(lastCompleteTime), Finite(lastTime)) =>
-//            Ok(
-//              Json.obj(
-//                "lastCompleteTime" -> lastCompleteTime.asJson,
-//                "lastTime" -> lastTime.asJson
-//              )
-//            )
-//          case _ => BadRequest
-//        }
-//      }
-//
-//    case GET at url"/api/timeseries/backfills" =>
-//      Database
-//        .queryBackfills()
-//        .to[List]
-//        .map(_.map {
-//          case (id, name, description, jobs, priority, start, end, created_at, status, created_by) =>
-//            Json.obj(
-//              "id" -> id.asJson,
-//              "name" -> name.asJson,
-//              "description" -> description.asJson,
-//              "jobs" -> jobs.asJson,
-//              "priority" -> priority.asJson,
-//              "start" -> start.asJson,
-//              "end" -> end.asJson,
-//              "created_at" -> created_at.asJson,
-//              "status" -> status.asJson,
-//              "created_by" -> created_by.asJson
-//            )
-//        })
-//        .transact(xa)
-//        .map(backfills => Ok(backfills.asJson))
-//    case GET at url"/api/timeseries/backfills/$id?events=$events" =>
-//      val backfills = Database.getBackfillById(id).transact(xa)
-//      events match {
-//        case "true" | "yes" => sse(backfills, (b: Json) => IO.pure(b))
-//        case _              => backfills.map(bf => Ok(bf.asJson))
-//      }
-//    case GET at url"/api/timeseries/backfills/$backfillId/executions?events=$events&limit=$l&offset=$o&sort=$sort&order=$a" => {
-//      val limit = Try(l.toInt).toOption.getOrElse(25)
-//      val offset = Try(o.toInt).toOption.getOrElse(0)
-//      val asc = (a.toLowerCase == "asc")
-//      def asTotalJson(x: (Int, Double, Seq[ExecutionLog])) = x match {
-//        case (total, completion, executions) =>
-//          Json.obj(
-//            "total" -> total.asJson,
-//            "offset" -> offset.asJson,
-//            "limit" -> limit.asJson,
-//            "sort" -> sort.asJson,
-//            "asc" -> asc.asJson,
-//            "data" -> executions.asJson,
-//            "completion" -> completion.asJson
-//          )
-//      }
-//      val ordering = {
-//        val columnOrdering = sort match {
-//          case "job"       => Ordering.by((_: ExecutionLog).job)
-//          case "startTime" => Ordering.by((_: ExecutionLog).startTime)
-//          case "status"    => Ordering.by((_: ExecutionLog).status.toString)
-//          case _           => Ordering.by((_: ExecutionLog).id)
-//        }
-//        if (asc) {
-//          columnOrdering
-//        } else {
-//          columnOrdering.reverse
-//        }
-//      }
-//      def allExecutions(): IO[Option[(Int, Double, List[ExecutionLog])]] = {
-//
-//        val runningExecutions = executor.runningExecutions
-//          .filter(t => {
-//            val bf = t._1.context.backfill
-//            bf.isDefined && bf.get.id == backfillId
-//          })
-//          .map({ case (execution, status) => execution.toExecutionLog(status) })
-//
-//        val runningExecutionsIds = runningExecutions.map(_.id).toSet
-//        Database
-//          .getExecutionLogsForBackfill(backfillId)
-//          .transact(xa)
-//          .map(archived => {
-//            val archivedNotRunning = archived.filterNot(e => runningExecutionsIds.contains(e.id))
-//            val executions = runningExecutions ++ archivedNotRunning
-//            val completion = {
-//              executions.size match {
-//                case 0     => 0
-//                case total => (total - runningExecutions.size).toDouble / total
-//              }
-//            }
-//            Some((executions.size, completion, executions.sorted(ordering).drop(offset).take(limit).toList))
-//          })
-//      }
-//
-//      events match {
-//        case "true" | "yes" =>
-//          sse(allExecutions(), (e: (Int, Double, List[ExecutionLog])) => IO.pure(asTotalJson(e)))
-//        case _ =>
-//          allExecutions().map(_.map(e => Ok(asTotalJson(e))).getOrElse(NotFound))
-//      }
-//    }
-//  }: PartialService
+    case GET at "/api/jobs/paused" =>
+      Ok(scheduler.getPausedJobs.asJson)
 
-//  private[timeseries] def privateRoutes(): AuthenticatedService = {
-//    case req @ POST at url"/api/timeseries/backfill" => { implicit user =>
-//      req
-//        .readAs[Json]
-//        .flatMap(
-//          _.as[BackfillCreate]
-//            .fold(
-//              df =>
-//                IO.pure(
-//                  BadRequest(
-//                    s"""
-//                         |Error during backfill creation.
-//                         |Error: Cannot parse request body.
-//                         |$df
-//                         |""".stripMargin
-//                  )),
-//              backfill => {
-//                val jobIdsToBackfill = backfill.jobs.split(",").toSet
-//                scheduler
-//                  .backfillJob(
-//                    backfill.name,
-//                    backfill.description,
-//                    jobs.all.filter(job => jobIdsToBackfill.contains(job.id)),
-//                    backfill.startDate,
-//                    backfill.endDate,
-//                    backfill.priority,
-//                    executor.runningState,
-//                    xa
-//                  )
-//                  .map {
-//                    case Right(_)     => Ok("ok".asJson)
-//                    case Left(errors) => BadRequest(errors)
-//                  }
-//              }
-//            )
-//        )
-//    }
-//
-//    // consider the given period of the job as successful, regardless of it's actual status
-//    case req @ GET at url"/api/timeseries/force-success?job=$jobId&start=$start&end=$end" => { implicit user =>
-//      (for {
-//        startDate <- Try(Instant.parse(start))
-//        endDate <- Try(Instant.parse(end))
-//        job <- Try(project.jobs.all.find(_.id == jobId).getOrElse(throw new Exception(s"Unknow job $jobId")))
-//      } yield {
-//        val requestedInterval = Interval(startDate, endDate)
-//        //self.forceSuccess(job, requestedInterval, executor.cuttleProject.version)
-//        scheduler.forceSuccess(job, requestedInterval, executor.projectVersion)
-//        val runningExecutions = executor.runningExecutions.filter(e => e._1.job.id == jobId).map(_._1)
-//        val failingExecutions = executor.allFailingExecutions.filter(_.job.id == jobId)
-//        val executions = runningExecutions ++ failingExecutions
-//        executions.foreach(_.cancel())
-//        (executions.length, JobSuccessForced(Instant.now(), user, jobId, startDate, endDate))
-//      }) match {
-//        case Success((canceledExecutions, event)) =>
-//          queries
-//            .logEvent(event)
-//            .transact(xa)
-//            .map(_ => Ok(Json.obj("canceled-executions" -> Json.fromInt(canceledExecutions))))
-//        case Failure(e) =>
-//          IO.pure(BadRequest(Json.obj("error" -> Json.fromString(e.getMessage))))
-//      }
-//    }
-//  }
+    case GET at url"/api/cron/executions?job=$job&start=$start&end=$end" =>
+      val jsonOrError: EitherT[IO, Throwable, Json] = for {
+        job <- EitherT.fromOption[IO](workload.all.find(_.id == job), throw new Exception(s"Unknow job $job"))
+        startDate <- EitherT.rightT[IO, Throwable](Try(Instant.parse(start)).getOrElse(minStartDateForExecutions))
+        endDate <- EitherT.rightT[IO, Throwable](Try(Instant.parse(end)).getOrElse(maxStartDateForExecutions))
+        archived <- {
+          val context = Database.sqlGetContextsBetween(startDate, endDate)
+          EitherT.right[Throwable](
+            executor.archivedExecutions(context, Set(job.id), "", asc = true, 0, Int.MaxValue, transactor))
+        }
+        running <- EitherT.rightT[IO, Throwable](executor.runningExecutions.collect {
+          case (e, status)
+              if e.job.id == job && e.context.instant.isAfter(startDate) && e.context.instant.isBefore(endDate) =>
+            e.toExecutionLog(status)
+        })
+      } yield (archived ++ running).asJson
 
-//  private val api = publicApi //orElse project.authenticator(privateApi)
-
-  private val publicAssets: PartialService = {
-    case GET at url"/public/$file" => ClasspathResource(s"/public/$file").fold(NotFound)(Ok(_))
+      jsonOrError.value.map {
+        case Right(json) => Ok(json)
+        case Left(e)     => BadRequest(Json.obj("error" -> Json.fromString(e.getMessage)))
+      }
   }
 
-  private val index: AuthenticatedService = {
-    case req if req.url.startsWith("/api/") =>
-      _ =>
-        NotFound
-    case _ =>
-      _ =>
-        Ok(ClasspathResource("/public/index.html"))
+  val privateApi: AuthenticatedService = {
+    case req @ GET at url"/api/shutdown" => { implicit user =>
+      import scala.concurrent.duration._
+
+      req.queryStringParameters.get("gracePeriodSeconds") match {
+        case Some(s) =>
+          Try(s.toLong) match {
+            case Success(s) if s > 0 =>
+              executor.gracefulShutdown(Duration(s, TimeUnit.SECONDS))
+              Ok
+            case _ =>
+              BadRequest("gracePeriodSeconds should be a positive integer")
+          }
+        case None =>
+          req.queryStringParameters.get("hard") match {
+            case Some(_) =>
+              executor.hardShutdown()
+              Ok
+            case None =>
+              BadRequest("Either gracePeriodSeconds or hard should be specified as query parameter")
+          }
+      }
+    }
+
+    case POST at url"/api/jobs/$id/pause" => { implicit user =>
+      workload.all.find(_.id == id).fold(NotFound) { job =>
+        scheduler.pauseJobs(Set(job), executor)
+        Ok
+      }
+    }
+
+    case POST at url"/api/jobs/$id/resume" => { implicit user =>
+      workload.all.find(_.id == id).fold(NotFound) { job =>
+        scheduler.resumeJobs(Set(job), executor)
+        Ok
+      }
+    }
+
   }
 
-  val routes: PartialService = ??? //api
-//    .orElse(publicRoutes())
-//    .orElse(project.authenticator(privateRoutes()))
-//    .orElse {
-//      executor.platforms.foldLeft(PartialFunction.empty: PartialService) {
-//        case (s, p) => s.orElse(p.publicRoutes).orElse(project.authenticator(p.privateRoutes))
-//      }
-//    }
-//    .orElse(publicAssets orElse project.authenticator(index))
+  private val api = publicApi orElse project.authenticator(privateApi)
+
+  val routes: PartialService = api.orElse {
+    case _ => NotFound
+  }
 }

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronApp.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronApp.scala
@@ -1,0 +1,888 @@
+package com.criteo.cuttle.cron
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+
+import scala.util._
+
+import cats.effect.IO
+import cats.implicits._
+import com.criteo.cuttle.Auth._
+import com.criteo.cuttle.ExecutionStatus._
+import com.criteo.cuttle.Metrics.{Gauge, Prometheus}
+import com.criteo.cuttle._
+import com.criteo.cuttle.events.JobSuccessForced
+import com.criteo.cuttle.utils.getJVMUptime
+import doobie.implicits._
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.java8.time._
+import io.circe.syntax._
+import lol.http._
+import lol.json._
+
+private[cron] case class CronApp() {
+
+//  private val allIds = jobs.all.map(_.id)
+//
+//  private def parseJobIds(jobsQueryString: String): Set[String] =
+//    jobsQueryString.split(",").filter(_.trim().nonEmpty).toSet
+//
+//  private def getJobsOrNotFound(jobsQueryString: String): Either[Response, Set[Job[TimeSeries]]] = {
+//    val jobsNames = parseJobIds(jobsQueryString)
+//    if (jobsNames.isEmpty) Right(jobs.all)
+//    else {
+//      val filteredJobs = jobs.all.filter(v => jobsNames.contains(v.id))
+//      if (filteredJobs.isEmpty) Left(NotFound)
+//      else Right(filteredJobs)
+//    }
+//  }
+
+//  val publicApi: PartialService = {
+//
+//    case GET at url"/api/status" => {
+//      val projectJson = (status: String) =>
+//        Json.obj(
+//          "project" -> project.name.asJson,
+//          "version" -> Option(project.version).filterNot(_.isEmpty).asJson,
+//          "status" -> status.asJson
+//      )
+//      executor.healthCheck() match {
+//        case Success(_) => Ok(projectJson("ok"))
+//        case _          => InternalServerError(projectJson("ko"))
+//      }
+//    }
+//
+//    case GET at url"/api/statistics?events=$events&jobs=$jobs" =>
+//      val jobIds = parseJobIds(jobs)
+//      val ids = if (jobIds.isEmpty) allIds else jobIds
+//
+//      def getStats: IO[Option[(Json, Json)]] =
+//        executor
+//          .getStats(ids)
+//          .map(
+//            stats =>
+//              Try(
+//                stats -> scheduler.getStats(ids)
+//              ).toOption)
+//
+//      def asJson(x: (Json, Json)) = x match {
+//        case (executorStats, schedulerStats) =>
+//          executorStats.deepMerge(
+//            Json.obj(
+//              "scheduler" -> schedulerStats
+//            ))
+//      }
+//
+//      events match {
+//        case "true" | "yes" =>
+//          sse(IO.suspend(getStats), (x: (Json, Json)) => IO(asJson(x)))
+//        case _ => getStats.map(_.map(stat => Ok(asJson(stat))).getOrElse(InternalServerError))
+//      }
+//
+//    case GET at url"/api/statistics/$jobName" =>
+//      executor
+//        .jobStatsForLastThirtyDays(jobName)
+//        .map(stats => Ok(stats.asJson))
+//
+//    case GET at url"/version" => Ok(project.version)
+//
+//    case GET at "/metrics" =>
+//      val metrics =
+//        executor.getMetrics(allIds, jobs) ++
+//          scheduler.getMetrics(allIds, jobs) :+
+//          Gauge("cuttle_jvm_uptime_seconds").labeled(("version", project.version), getJVMUptime)
+//      Ok(Prometheus.serialize(metrics))
+//
+//    case GET at url"/api/executions/status/$kind?limit=$l&offset=$o&events=$events&sort=$sort&order=$order&jobs=$jobs" =>
+//      logger.debug(s"Retreiving $kind executions with sse mode $events")
+//      val jobIds = parseJobIds(jobs)
+//      val limit = Try(l.toInt).toOption.getOrElse(25)
+//      val offset = Try(o.toInt).toOption.getOrElse(0)
+//      val asc = order.toLowerCase == "asc"
+//      val ids = if (jobIds.isEmpty) allIds else jobIds
+//
+//      def getExecutions: IO[Option[(Int, List[ExecutionLog])]] = kind match {
+//        case "started" =>
+//          IO(
+//            Some(
+//              executor.runningExecutionsSizeTotal(ids) -> executor
+//                .runningExecutions(ids, sort, asc, offset, limit)
+//                .toList))
+//        case "stuck" =>
+//          IO(
+//            Some(
+//              executor.failingExecutionsSize(ids) -> executor
+//                .failingExecutions(ids, sort, asc, offset, limit)
+//                .toList))
+//        case "finished" =>
+//          executor
+//            .archivedExecutionsSize(ids)
+//            .map(ids => Some(ids -> executor.allRunning.toList))
+//        case _ =>
+//          IO.pure(None)
+//      }
+//
+//      def asJson(x: (Int, Seq[ExecutionLog])): IO[Json] = x match {
+//        case (total, executions) =>
+//          (kind match {
+//            case "finished" =>
+//              executor
+//                .archivedExecutions(scheduler.allContexts, ids, sort, asc, offset, limit, xa)
+//                .map(execs => execs.asJson)
+//            case _ =>
+//              IO(executions.asJson)
+//          }).map(
+//            data =>
+//              Json.obj(
+//                "total" -> total.asJson,
+//                "offset" -> offset.asJson,
+//                "limit" -> limit.asJson,
+//                "sort" -> sort.asJson,
+//                "asc" -> asc.asJson,
+//                "data" -> data
+//            ))
+//      }
+//
+//      events match {
+//        case "true" | "yes" =>
+//          sse(getExecutions, asJson)
+//        case _ =>
+//          getExecutions
+//            .flatMap(
+//              _.map(e => asJson(e).map(json => Ok(json)))
+//                .getOrElse(NotFound))
+//      }
+//
+//    case GET at url"/api/executions/$id?events=$events" =>
+//      def getExecution = IO.suspend(executor.getExecution(scheduler.allContexts, id))
+//
+//      events match {
+//        case "true" | "yes" =>
+//          sse(getExecution, (e: ExecutionLog) => IO(e.asJson))
+//        case _ =>
+//          getExecution.map(_.map(e => Ok(e.asJson)).getOrElse(NotFound))
+//      }
+//
+//    case req @ GET at url"/api/executions/$id/streams" =>
+//      lazy val streams = executor.openStreams(id)
+//      req.headers.get(h"Accept").contains(h"text/event-stream") match {
+//        case true =>
+//          Ok(
+//            fs2.Stream(ServerSentEvents.Event("BOS".asJson)) ++
+//              streams
+//                .through(fs2.text.utf8Decode)
+//                .through(fs2.text.lines)
+//                .chunks
+//                .map(chunk => ServerSentEvents.Event(Json.fromValues(chunk.toArray.toIterable.map(_.asJson)))) ++
+//              fs2.Stream(ServerSentEvents.Event("EOS".asJson))
+//          )
+//        case false =>
+//          Ok(
+//            Content(
+//              stream = streams,
+//              headers = Map(h"Content-Type" -> h"text/plain")
+//            ))
+//      }
+//
+//    case GET at "/api/jobs/paused" =>
+//      Ok(scheduler.pausedJobs().asJson)
+//
+//    case GET at "/api/project_definition" =>
+//      Ok(project.asJson)
+//
+//    case GET at "/api/jobs_definition" =>
+//      Ok(jobs.asJson)
+//  }
+
+//  val privateApi: AuthenticatedService = {
+//    case POST at url"/api/executions/$id/cancel" => { implicit user =>
+//      executor.cancelExecution(id)
+//      Ok
+//    }
+//
+//    case POST at url"/api/jobs/pause?jobs=$jobs" => { implicit user =>
+//      getJobsOrNotFound(jobs).fold(IO.pure, jobs => {
+//        scheduler.pauseJobs(jobs, executor, xa)
+//        Ok
+//      })
+//    }
+//
+//    case POST at url"/api/jobs/resume?jobs=$jobs" => { implicit user =>
+//      getJobsOrNotFound(jobs).fold(IO.pure, jobs => {
+//        scheduler.resumeJobs(jobs, xa)
+//        Ok
+//      })
+//    }
+//    case POST at url"/api/jobs/all/unpause" => { implicit user =>
+//      scheduler.resumeJobs(jobs.all, xa)
+//      Ok
+//    }
+//    case POST at url"/api/jobs/$id/unpause" => { implicit user =>
+//      jobs.all.find(_.id == id).fold(NotFound) { job =>
+//        scheduler.resumeJobs(Set(job), xa)
+//        Ok
+//      }
+//    }
+//    case POST at url"/api/executions/relaunch?jobs=$jobs" => { implicit user =>
+//      val filteredJobs = Try(jobs.split(",").toSeq.filter(_.nonEmpty)).toOption
+//        .filter(_.nonEmpty)
+//        .getOrElse(allIds)
+//        .toSet
+//
+//      executor.relaunch(filteredJobs)
+//      IO.pure(Ok)
+//    }
+//
+//    case req @ GET at url"/api/shutdown" => { implicit user =>
+//      import scala.concurrent.duration._
+//
+//      req.queryStringParameters.get("gracePeriodSeconds") match {
+//        case Some(s) =>
+//          Try(s.toLong) match {
+//            case Success(s) if s > 0 =>
+//              executor.gracefulShutdown(Duration(s, TimeUnit.SECONDS))
+//              Ok
+//            case _ =>
+//              BadRequest("gracePeriodSeconds should be a positive integer")
+//          }
+//        case None =>
+//          req.queryStringParameters.get("hard") match {
+//            case Some(_) =>
+//              executor.hardShutdown()
+//              Ok
+//            case None =>
+//              BadRequest("Either gracePeriodSeconds or hard should be specified as query parameter")
+//          }
+//      }
+//    }
+//  }
+//
+//  private implicit val intervalEncoder = new Encoder[Interval[Instant]] {
+//    implicit val boundEncoder = new Encoder[Bound[Instant]] {
+//      override def apply(bound: Bound[Instant]) = bound match {
+//        case Bottom    => "-oo".asJson
+//        case Top       => "+oo".asJson
+//        case Finite(t) => t.asJson
+//      }
+//    }
+//
+//    override def apply(interval: Interval[Instant]) =
+//      Json.obj(
+//        "start" -> interval.lo.asJson,
+//        "end" -> interval.hi.asJson
+//      )
+//  }
+//  private val queries = new Queries {}
+
+//  private trait ExecutionPeriod {
+//    val period: Interval[Instant]
+//    val backfill: Boolean
+//    val aggregated: Boolean
+//    val version: String
+//  }
+
+//  private case class JobExecution(period: Interval[Instant], status: String, backfill: Boolean, version: String)
+//      extends ExecutionPeriod {
+//    override val aggregated: Boolean = false
+//  }
+
+//  private case class AggregatedJobExecution(period: Interval[Instant],
+//                                            completion: Double,
+//                                            error: Boolean,
+//                                            backfill: Boolean,
+//                                            version: String = "")
+//      extends ExecutionPeriod {
+//    override val aggregated: Boolean = true
+//  }
+
+//  private case class JobTimeline(jobId: String, calendarView: TimeSeriesCalendarView, executions: List[ExecutionPeriod])
+
+//  private implicit val executionPeriodEncoder = new Encoder[ExecutionPeriod] {
+//    override def apply(executionPeriod: ExecutionPeriod) = {
+//      val coreFields = List(
+//        "period" -> executionPeriod.period.asJson,
+//        "backfill" -> executionPeriod.backfill.asJson,
+//        "aggregated" -> executionPeriod.aggregated.asJson,
+//        "version" -> executionPeriod.version.asJson
+//      )
+//      val finalFields = executionPeriod match {
+//        case JobExecution(_, status, _, _) => ("status" -> status.asJson) :: coreFields
+//        case AggregatedJobExecution(_, completion, error, _, _) =>
+//          ("completion" -> completion.asJson) :: ("error" -> error.asJson) :: coreFields
+//      }
+//      Json.obj(finalFields: _*)
+//    }
+//  }
+
+//  private implicit val jobTimelineEncoder = new Encoder[JobTimeline] {
+//    override def apply(jobTimeline: JobTimeline) = jobTimeline.executions.asJson
+//  }
+
+//  case class ExecutionDetails(jobExecutions: Seq[ExecutionLog], parentExecutions: Seq[ExecutionLog])
+
+//  private implicit val executionDetailsEncoder: Encoder[ExecutionDetails] =
+//    Encoder.forProduct2("jobExecutions", "parentExecutions")(
+//      e => (e.jobExecutions, e.parentExecutions)
+//    )
+
+//  private[timeseries] def publicRoutes(): PartialService = {
+//    case request @ GET at url"/api/timeseries/executions?job=$jobId&start=$start&end=$end" =>
+//      type WatchedState = ((State, Set[Backfill]), Set[(Job[TimeSeries], TimeSeriesContext)])
+//
+//      def watchState(): Option[WatchedState] = Some((scheduler.state, executor.allFailingJobsWithContext))
+//
+//      def getExecutions(watchedState: WatchedState): IO[Json] = {
+//        val job = jobs.vertices.find(_.id == jobId).get
+//        val calendar = job.scheduling.calendar
+//        val startDate = Instant.parse(start)
+//        val endDate = Instant.parse(end)
+//        val requestedInterval = Interval(startDate, endDate)
+//        val contextQuery = Database.sqlGetContextsBetween(Some(startDate), Some(endDate))
+//        val archivedExecutions =
+//          executor.archivedExecutions(contextQuery, Set(jobId), "", asc = true, 0, Int.MaxValue, xa)
+//        val runningExecutions = executor.runningExecutions
+//          .filter {
+//            case (e, _) =>
+//              e.job.id == jobId && e.context.toInterval.intersects(requestedInterval)
+//          }
+//          .map { case (e, status) => e.toExecutionLog(status) }
+//
+//        val ((jobStates, _), _) = watchedState
+//        val remainingExecutions =
+//          for {
+//            (interval, maybeBackfill) <- jobStates(job)
+//              .intersect(requestedInterval)
+//              .toList
+//              .collect { case (itvl, Todo(maybeBackfill)) => (itvl, maybeBackfill) }
+//            (lo, hi) <- calendar.split(interval)
+//          } yield {
+//            val context =
+//              TimeSeriesContext(calendar.truncate(lo), calendar.ceil(hi), maybeBackfill, executor.projectVersion)
+//            ExecutionLog("", job.id, None, None, context.asJson, ExecutionTodo, None, 0)
+//          }
+//        val throttledExecutions = executor.allFailingExecutions
+//          .filter(e => e.job == job && e.context.toInterval.intersects(requestedInterval))
+//          .map(_.toExecutionLog(ExecutionThrottled))
+//
+//        archivedExecutions.map(
+//          archivedExecutions =>
+//            ExecutionDetails(archivedExecutions ++ runningExecutions ++ remainingExecutions ++ throttledExecutions,
+//                             parentExecutions(requestedInterval, job, jobStates)).asJson)
+//      }
+//
+//      def parentExecutions(requestedInterval: Interval[Instant],
+//                           job: Job[TimeSeries],
+//                           state: Map[Job[TimeSeries], IntervalMap[Instant, JobState]]): Seq[ExecutionLog] = {
+//
+//        val calendar = job.scheduling.calendar
+//        val parentJobs = jobs.edges
+//          .collect({ case (child, parent, _) if child == job => parent })
+//        val runningDependencies: Seq[ExecutionLog] = executor.runningExecutions
+//          .filter {
+//            case (e, _) => parentJobs.contains(e.job) && e.context.toInterval.intersects(requestedInterval)
+//          }
+//          .map({ case (e, status) => e.toExecutionLog(status) })
+//        val failingDependencies: Seq[ExecutionLog] = executor.allFailingExecutions
+//          .filter(e => parentJobs.contains(e.job) && e.context.toInterval.intersects(requestedInterval))
+//          .map(_.toExecutionLog(ExecutionThrottled))
+//        val remainingDependenciesDeps =
+//          for {
+//            parentJob <- parentJobs
+//            (interval, maybeBackfill) <- state(parentJob)
+//              .intersect(requestedInterval)
+//              .toList
+//              .collect { case (itvl, Todo(maybeBackfill)) => (itvl, maybeBackfill) }
+//            (lo, hi) <- calendar.split(interval)
+//          } yield {
+//            val context =
+//              TimeSeriesContext(calendar.truncate(lo), calendar.ceil(hi), maybeBackfill, executor.projectVersion)
+//            ExecutionLog("", parentJob.id, None, None, context.asJson, ExecutionTodo, None, 0)
+//          }
+//
+//        runningDependencies ++ failingDependencies ++ remainingDependenciesDeps.toSeq
+//      }
+//
+//      watchState() match {
+//        case Some(watchedState) =>
+//          if (request.headers.get(h"Accept").contains(h"text/event-stream"))
+//            sse(IO { Some(watchedState) }, (s: WatchedState) => getExecutions(s))
+//          else
+//            getExecutions(watchedState).map(Ok(_))
+//        case None =>
+//          BadRequest
+//      }
+//
+//    case request @ GET at url"/api/timeseries/calendar/focus?start=$start&end=$end&jobs=$jobs" =>
+//      type WatchedState = ((State, Set[Backfill]), Set[(Job[TimeSeries], TimeSeriesContext)])
+//
+//      val filteredJobs = Try(jobs.split(",").toSeq.filter(_.nonEmpty)).toOption
+//        .filter(_.nonEmpty)
+//        .getOrElse(project.jobs.all.map(_.id))
+//        .toSet
+//
+//      def watchState(): Option[WatchedState] = Some((scheduler.state, executor.allFailingJobsWithContext))
+//
+//      def getFocusView(watchedState: WatchedState) = {
+//        val startDate = Instant.parse(start)
+//        val endDate = Instant.parse(end)
+//        val period = Interval(startDate, endDate)
+//        val ((jobStates, backfills), _) = watchedState
+//        val backfillDomain =
+//          backfills.foldLeft(IntervalMap.empty[Instant, Unit]) { (acc, bf) =>
+//            if (bf.jobs.map(_.id).intersect(filteredJobs).nonEmpty)
+//              acc.update(Interval(bf.start, bf.end), ())
+//            else
+//              acc
+//          }
+//
+//        val pausedJobs = scheduler.pausedJobs().map(_.id)
+//        val allFailingExecutionIds = executor.allFailingExecutions.map(_.id).toSet
+//        val allWaitingExecutionIds = executor.allRunning
+//          .filter(_.status == ExecutionWaiting)
+//          .map(_.id)
+//          .toSet
+//
+//        def findAggregationLevel(n: Int,
+//                                 calendarView: TimeSeriesCalendarView,
+//                                 interval: Interval[Instant]): TimeSeriesCalendarView = {
+//          val aggregatedExecutions = calendarView.calendar.split(interval)
+//          if (aggregatedExecutions.size <= n)
+//            calendarView
+//          else
+//            findAggregationLevel(n, calendarView.upper(), interval)
+//        }
+//
+//        def aggregateExecutions(
+//          job: TimeSeriesJob,
+//          period: Interval[Instant],
+//          calendarView: TimeSeriesCalendarView): List[(Interval[Instant], List[(Interval[Instant], JobState)])] =
+//          calendarView.calendar
+//            .split(period)
+//            .flatMap { interval =>
+//              {
+//                val (start, end) = interval
+//                val currentlyAggregatedPeriod = jobStates(job)
+//                  .intersect(Interval(start, end))
+//                  .toList
+//                  .sortBy(_._1.lo)
+//                currentlyAggregatedPeriod match {
+//                  case Nil => None
+//                  case _   => Some((Interval(start, end), currentlyAggregatedPeriod))
+//                }
+//              }
+//            }
+//
+//        def getVersionFromState(jobState: JobState): String = jobState match {
+//          case Done(version) => version
+//          case _             => ""
+//        }
+//
+//        def getStatusLabelFromState(jobState: JobState, job: Job[TimeSeries]): String =
+//          jobState match {
+//            case Running(executionId) =>
+//              if (allFailingExecutionIds.contains(executionId))
+//                "failed"
+//              else if (allWaitingExecutionIds.contains(executionId))
+//                "waiting"
+//              else if (pausedJobs.contains(job.id))
+//                "paused"
+//              else "running"
+//            case Todo(_) => if (pausedJobs.contains(job.id)) "paused" else "todo"
+//            case Done(_) => "successful"
+//          }
+//
+//        val jobTimelines =
+//          (for { job <- project.jobs.all if filteredJobs.contains(job.id) } yield {
+//            val calendarView = findAggregationLevel(
+//              48,
+//              TimeSeriesCalendarView(job.scheduling.calendar),
+//              period
+//            )
+//            val jobExecutions: List[Option[ExecutionPeriod]] = for {
+//              (interval, jobStatesOnIntervals) <- aggregateExecutions(job, period, calendarView)
+//            } yield {
+//              val inBackfill = backfills.exists(
+//                bf =>
+//                  bf.jobs.contains(job) &&
+//                    IntervalMap(interval -> 0)
+//                      .intersect(Interval(bf.start, bf.end))
+//                      .toList
+//                      .nonEmpty)
+//              if (calendarView.aggregationFactor == 1) {
+//                jobStatesOnIntervals match {
+//                  case (_, state) :: Nil =>
+//                    Some(JobExecution(interval, getStatusLabelFromState(state, job), inBackfill, getVersionFromState(state)))
+//                  case _ => None
+//                }
+//              }
+//              else {
+//                jobStatesOnIntervals match {
+//                  case jobStates: List[(Interval[Instant], JobState)] if jobStates.nonEmpty => {
+//                    val (duration, done, error) = jobStates.foldLeft((0L, 0L, false)) {
+//                      case ((accumulatedDuration, accumulatedDoneDuration, hasErrors), (period, jobState)) =>
+//                        val (lo, hi) = period.toPair
+//                        val jobStatus = getStatusLabelFromState(jobState, job)
+//                        (accumulatedDuration + lo.until(hi, ChronoUnit.SECONDS),
+//                         accumulatedDoneDuration + (if (jobStatus == "successful") lo.until(hi, ChronoUnit.SECONDS) else 0),
+//                         hasErrors || jobStatus == "failed")
+//                    }
+//                    Some(AggregatedJobExecution(interval, done.toDouble / duration.toDouble, error, inBackfill))
+//                  }
+//                  case Nil => None
+//                }
+//              }
+//            }
+//            JobTimeline(job.id, calendarView, jobExecutions.flatten)
+//          }).toList
+//
+//        Json.obj(
+//          "summary" -> jobTimelines
+//            .maxBy(_.executions.size)
+//            .calendarView
+//            .calendar
+//            .split(period)
+//            .flatMap {
+//              case (lo, hi) =>
+//                val isInbackfill = backfillDomain.intersect(Interval(lo, hi)).toList.nonEmpty
+//
+//              case class JobSummary(periodLengthInSeconds: Long, periodDoneInSeconds: Long, hasErrors: Boolean)
+//
+//                val jobSummaries: Set[JobSummary] = for {
+//                  job <- project.jobs.all
+//                  if filteredJobs.contains(job.id)
+//                  (interval, jobState) <- jobStates(job).intersect(Interval(lo, hi)).toList
+//                } yield {
+//                  val (lo, hi) = interval.toPair
+//                  JobSummary(
+//                    periodLengthInSeconds = lo.until(hi, ChronoUnit.SECONDS),
+//                    periodDoneInSeconds = jobState match {
+//                      case Done(_) => lo.until(hi, ChronoUnit.SECONDS)
+//                      case _       => 0
+//                    },
+//                    hasErrors = jobState match {
+//                      case Running(executionId) => allFailingExecutionIds.contains(executionId)
+//                      case _          => false
+//                    })
+//                }
+//                if (jobSummaries.nonEmpty) {
+//                  val aggregatedJobSummary = jobSummaries.reduce { (a: JobSummary, b: JobSummary) =>
+//                    JobSummary(a.periodLengthInSeconds + b.periodLengthInSeconds,
+//                               a.periodDoneInSeconds + b.periodDoneInSeconds,
+//                               a.hasErrors || b.hasErrors)
+//                  }
+//                  Some(
+//                    AggregatedJobExecution(
+//                      Interval(lo, hi),
+//                      aggregatedJobSummary.periodDoneInSeconds.toDouble / aggregatedJobSummary.periodLengthInSeconds.toDouble,
+//                      aggregatedJobSummary.hasErrors, isInbackfill
+//                    )
+//                  )
+//                } else {
+//                  None
+//                }
+//            }
+//            .asJson,
+//          "jobs" -> jobTimelines.map(jt => jt.jobId -> jt).toMap.asJson
+//        )
+//      }
+//
+//      if (request.headers.get(h"Accept").contains(h"text/event-stream"))
+//        sse(IO { watchState() }, (s: WatchedState) => IO(getFocusView(s)))
+//      else
+//        watchState() match {
+//          case Some(watchedState) => Ok(getFocusView(watchedState))
+//          case None               => BadRequest
+//        }
+//
+//    case request @ GET at url"/api/timeseries/calendar?jobs=$jobs" =>
+//      val filteredJobs = Try(jobs.split(",").toSeq.filter(_.nonEmpty)).toOption
+//        .filter(_.nonEmpty)
+//        .getOrElse(project.jobs.all.map(_.id))
+//        .toSet
+//
+//      type WatchedState = ((TimeSeriesUtils.State, Set[Backfill]), Set[(Job[TimeSeries], TimeSeries#Context)])
+//
+//      case class JobStateOnPeriod(start: Instant, duration: Long, isDone: Boolean, isStuck: Boolean)
+//
+//      def watchState(): Option[WatchedState] = Some((scheduler.state, executor.allFailingJobsWithContext))
+//
+//      def getCalendar(watchedState: WatchedState): Json = {
+//        val ((jobStates, backfills), _) = watchedState
+//        val backfillDomain =
+//          backfills.foldLeft(IntervalMap.empty[Instant, Unit]) { (acc, bf) =>
+//            if (bf.jobs.map(_.id).intersect(filteredJobs).nonEmpty)
+//              acc.update(Interval(bf.start, bf.end), ())
+//            else
+//              acc
+//          }
+//        val upToMidnightToday = Interval(Bottom, Finite(Daily(UTC).ceil(Instant.now)))
+//
+//        lazy val failingExecutionIds = executor.allFailingExecutions.map(_.id).toSet
+//        val jobStatesOnPeriod: Set[JobStateOnPeriod] = for {
+//          job <- project.jobs.all
+//          if filteredJobs.contains(job.id)
+//          (interval, jobState) <- jobStates(job).intersect(upToMidnightToday).toList
+//          (start, end) <- Daily(UTC).split(interval)
+//        } yield
+//          JobStateOnPeriod(
+//            Daily(UTC).truncate(start),
+//            start.until(end, ChronoUnit.SECONDS),
+//            jobState match {
+//              case Done(_) => true
+//              case _       => false
+//            },
+//            jobState match {
+//              case Running(exec) => failingExecutionIds.contains(exec)
+//              case _             => false
+//            }
+//          )
+//
+//        jobStatesOnPeriod
+//          .groupBy { case JobStateOnPeriod(start, _, _, _) => start }
+//          .toList
+//          .sortBy { case (periodStart, _) => periodStart }
+//          .map {
+//            case (date, statesOnPeriod) =>
+//              val (total, done, stuck) = statesOnPeriod.foldLeft((0L, 0L, false)) {
+//                case (acc, JobStateOnPeriod(_, duration, isDone, isStuck)) =>
+//                  val (totalDuration, doneDuration, isAnyStuck) = acc
+//                  val newDone = if (isDone) duration else 0L
+//                  (totalDuration + duration, doneDuration + newDone, isAnyStuck || isStuck)
+//              }
+//              val completion = Math.floor((done.toDouble / total.toDouble) * 10) / 10
+//              val correctedCompletion =
+//                if (completion == 0 && done != 0) 0.1
+//                else completion
+//              Map(
+//                "date" -> date.atZone(UTC).toLocalDate.asJson,
+//                "completion" -> correctedCompletion.asJson
+//              ) ++ (if (stuck) Map("stuck" -> true.asJson) else Map.empty) ++
+//                (if (backfillDomain.intersect(Interval(date, Daily(UTC).next(date))).toList.nonEmpty)
+//                   Map("backfill" -> true.asJson)
+//                 else Map.empty)
+//          }
+//          .asJson
+//
+//      }
+//
+//      if (request.headers.get(h"Accept").contains(h"text/event-stream"))
+//        sse(IO { watchState() }, (s: WatchedState) => IO.pure(getCalendar(s)))
+//      else
+//        watchState() match {
+//          case Some(watchedState) => Ok(getCalendar(watchedState))
+//          case None               => BadRequest
+//        }
+//
+//    case GET at url"/api/timeseries/lastruns?job=$jobId" =>
+//      val (jobStates, _) = scheduler.state
+//      val successfulIntervalMaps = jobStates
+//        .filter(s => s._1.id == jobId)
+//        .values
+//        .flatMap(m => m.toList)
+//        .filter {
+//          case (interval, jobState) =>
+//            jobState match {
+//              case Done(_) => true
+//              case _       => false
+//            }
+//        }
+//        .foldLeft(IntervalMap.empty[Instant, Unit])((acc, elt) => acc.update(elt._1, ()))
+//        .toList
+//
+//      if (successfulIntervalMaps.isEmpty) NotFound
+//      else {
+//        (successfulIntervalMaps.head._1.hi, successfulIntervalMaps.last._1.hi) match {
+//          case (Finite(lastCompleteTime), Finite(lastTime)) =>
+//            Ok(
+//              Json.obj(
+//                "lastCompleteTime" -> lastCompleteTime.asJson,
+//                "lastTime" -> lastTime.asJson
+//              )
+//            )
+//          case _ => BadRequest
+//        }
+//      }
+//
+//    case GET at url"/api/timeseries/backfills" =>
+//      Database
+//        .queryBackfills()
+//        .to[List]
+//        .map(_.map {
+//          case (id, name, description, jobs, priority, start, end, created_at, status, created_by) =>
+//            Json.obj(
+//              "id" -> id.asJson,
+//              "name" -> name.asJson,
+//              "description" -> description.asJson,
+//              "jobs" -> jobs.asJson,
+//              "priority" -> priority.asJson,
+//              "start" -> start.asJson,
+//              "end" -> end.asJson,
+//              "created_at" -> created_at.asJson,
+//              "status" -> status.asJson,
+//              "created_by" -> created_by.asJson
+//            )
+//        })
+//        .transact(xa)
+//        .map(backfills => Ok(backfills.asJson))
+//    case GET at url"/api/timeseries/backfills/$id?events=$events" =>
+//      val backfills = Database.getBackfillById(id).transact(xa)
+//      events match {
+//        case "true" | "yes" => sse(backfills, (b: Json) => IO.pure(b))
+//        case _              => backfills.map(bf => Ok(bf.asJson))
+//      }
+//    case GET at url"/api/timeseries/backfills/$backfillId/executions?events=$events&limit=$l&offset=$o&sort=$sort&order=$a" => {
+//      val limit = Try(l.toInt).toOption.getOrElse(25)
+//      val offset = Try(o.toInt).toOption.getOrElse(0)
+//      val asc = (a.toLowerCase == "asc")
+//      def asTotalJson(x: (Int, Double, Seq[ExecutionLog])) = x match {
+//        case (total, completion, executions) =>
+//          Json.obj(
+//            "total" -> total.asJson,
+//            "offset" -> offset.asJson,
+//            "limit" -> limit.asJson,
+//            "sort" -> sort.asJson,
+//            "asc" -> asc.asJson,
+//            "data" -> executions.asJson,
+//            "completion" -> completion.asJson
+//          )
+//      }
+//      val ordering = {
+//        val columnOrdering = sort match {
+//          case "job"       => Ordering.by((_: ExecutionLog).job)
+//          case "startTime" => Ordering.by((_: ExecutionLog).startTime)
+//          case "status"    => Ordering.by((_: ExecutionLog).status.toString)
+//          case _           => Ordering.by((_: ExecutionLog).id)
+//        }
+//        if (asc) {
+//          columnOrdering
+//        } else {
+//          columnOrdering.reverse
+//        }
+//      }
+//      def allExecutions(): IO[Option[(Int, Double, List[ExecutionLog])]] = {
+//
+//        val runningExecutions = executor.runningExecutions
+//          .filter(t => {
+//            val bf = t._1.context.backfill
+//            bf.isDefined && bf.get.id == backfillId
+//          })
+//          .map({ case (execution, status) => execution.toExecutionLog(status) })
+//
+//        val runningExecutionsIds = runningExecutions.map(_.id).toSet
+//        Database
+//          .getExecutionLogsForBackfill(backfillId)
+//          .transact(xa)
+//          .map(archived => {
+//            val archivedNotRunning = archived.filterNot(e => runningExecutionsIds.contains(e.id))
+//            val executions = runningExecutions ++ archivedNotRunning
+//            val completion = {
+//              executions.size match {
+//                case 0     => 0
+//                case total => (total - runningExecutions.size).toDouble / total
+//              }
+//            }
+//            Some((executions.size, completion, executions.sorted(ordering).drop(offset).take(limit).toList))
+//          })
+//      }
+//
+//      events match {
+//        case "true" | "yes" =>
+//          sse(allExecutions(), (e: (Int, Double, List[ExecutionLog])) => IO.pure(asTotalJson(e)))
+//        case _ =>
+//          allExecutions().map(_.map(e => Ok(asTotalJson(e))).getOrElse(NotFound))
+//      }
+//    }
+//  }: PartialService
+
+//  private[timeseries] def privateRoutes(): AuthenticatedService = {
+//    case req @ POST at url"/api/timeseries/backfill" => { implicit user =>
+//      req
+//        .readAs[Json]
+//        .flatMap(
+//          _.as[BackfillCreate]
+//            .fold(
+//              df =>
+//                IO.pure(
+//                  BadRequest(
+//                    s"""
+//                         |Error during backfill creation.
+//                         |Error: Cannot parse request body.
+//                         |$df
+//                         |""".stripMargin
+//                  )),
+//              backfill => {
+//                val jobIdsToBackfill = backfill.jobs.split(",").toSet
+//                scheduler
+//                  .backfillJob(
+//                    backfill.name,
+//                    backfill.description,
+//                    jobs.all.filter(job => jobIdsToBackfill.contains(job.id)),
+//                    backfill.startDate,
+//                    backfill.endDate,
+//                    backfill.priority,
+//                    executor.runningState,
+//                    xa
+//                  )
+//                  .map {
+//                    case Right(_)     => Ok("ok".asJson)
+//                    case Left(errors) => BadRequest(errors)
+//                  }
+//              }
+//            )
+//        )
+//    }
+//
+//    // consider the given period of the job as successful, regardless of it's actual status
+//    case req @ GET at url"/api/timeseries/force-success?job=$jobId&start=$start&end=$end" => { implicit user =>
+//      (for {
+//        startDate <- Try(Instant.parse(start))
+//        endDate <- Try(Instant.parse(end))
+//        job <- Try(project.jobs.all.find(_.id == jobId).getOrElse(throw new Exception(s"Unknow job $jobId")))
+//      } yield {
+//        val requestedInterval = Interval(startDate, endDate)
+//        //self.forceSuccess(job, requestedInterval, executor.cuttleProject.version)
+//        scheduler.forceSuccess(job, requestedInterval, executor.projectVersion)
+//        val runningExecutions = executor.runningExecutions.filter(e => e._1.job.id == jobId).map(_._1)
+//        val failingExecutions = executor.allFailingExecutions.filter(_.job.id == jobId)
+//        val executions = runningExecutions ++ failingExecutions
+//        executions.foreach(_.cancel())
+//        (executions.length, JobSuccessForced(Instant.now(), user, jobId, startDate, endDate))
+//      }) match {
+//        case Success((canceledExecutions, event)) =>
+//          queries
+//            .logEvent(event)
+//            .transact(xa)
+//            .map(_ => Ok(Json.obj("canceled-executions" -> Json.fromInt(canceledExecutions))))
+//        case Failure(e) =>
+//          IO.pure(BadRequest(Json.obj("error" -> Json.fromString(e.getMessage))))
+//      }
+//    }
+//  }
+
+//  private val api = publicApi //orElse project.authenticator(privateApi)
+
+  private val publicAssets: PartialService = {
+    case GET at url"/public/$file" => ClasspathResource(s"/public/$file").fold(NotFound)(Ok(_))
+  }
+
+  private val index: AuthenticatedService = {
+    case req if req.url.startsWith("/api/") =>
+      _ =>
+        NotFound
+    case _ =>
+      _ =>
+        Ok(ClasspathResource("/public/index.html"))
+  }
+
+  val routes: PartialService = ??? //api
+//    .orElse(publicRoutes())
+//    .orElse(project.authenticator(privateRoutes()))
+//    .orElse {
+//      executor.platforms.foldLeft(PartialFunction.empty: PartialService) {
+//        case (s, p) => s.orElse(p.publicRoutes).orElse(project.authenticator(p.privateRoutes))
+//      }
+//    }
+//    .orElse(publicAssets orElse project.authenticator(index))
+}

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronModel.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronModel.scala
@@ -3,11 +3,17 @@ package com.criteo.cuttle.cron
 import java.time.temporal.ChronoUnit
 import java.time.{Duration, Instant, ZoneOffset}
 
-import com.criteo.cuttle.{Job, Scheduling, SchedulingContext, Workload}
+import scala.concurrent.duration._
+import scala.concurrent.stm.{Ref, _}
+
 import cron4s.{Cron, _}
 import cron4s.lib.javatime._
+import io.circe._
+import io.circe.syntax._
+import io.circe.java8.time._
 
-import scala.concurrent.duration._
+import com.criteo.cuttle.Auth.User
+import com.criteo.cuttle.{ExecutionStatus, Logger, PausedJob, Scheduling, SchedulingContext, Workload}
 
 private[cron] case class ScheduledAt(instant: Instant, delay: FiniteDuration)
 
@@ -20,6 +26,113 @@ private[cron] case class CronContext(instant: Instant)(retryNum: Int) extends Sc
   def compareTo(other: SchedulingContext): Int = other match {
     case CronContext(otherInstant) =>
       instant.compareTo(otherInstant)
+  }
+
+  override def asJson: Json = CronContext.encoder(this)
+}
+
+private[cron] case object CronContext {
+  implicit val encoder: Encoder[CronContext] = Encoder.forProduct2("interval", "retry")(cc => cc.instant -> cc.retry)
+  implicit def decoder: Decoder[CronContext] =
+    Decoder.forProduct2[CronContext, Instant, Int]("interval", "retry")((instant: Instant, retry: Int) =>
+      CronContext(instant)(retry))
+}
+
+/**
+  * The state of Cron Scheduler that allows concurrently safe mutations.
+  */
+private[cron] case class CronState(logger: Logger) {
+  private val executions = Ref(Map.empty[CronJob, Either[Instant, CronExecution]])
+  private val paused = Ref(Map.empty[CronJob, PausedJob])
+
+  private[cron] def init(availableJobs: Set[CronJob], pausedJobs: Seq[PausedJob]) = {
+    logger.debug("Cron Scheduler States initialization")
+    val available = availableJobs.map(job => job.id -> job).toMap
+    val initialPausedJobs = pausedJobs.collect {
+      case pausedJob if available.contains(pausedJob.id) =>
+        logger.debug(s"Job ${pausedJob.id} is paused")
+        available(pausedJob.id) -> pausedJob
+    }.toMap
+
+    atomic { implicit txn =>
+      paused() = initialPausedJobs
+    }
+  }
+
+  private[cron] def getPausedJobs(): Set[PausedJob] = paused.single.get.values.toSet
+  private[cron] def isPaused(job: CronJob): Boolean = paused.single.get.contains(job)
+
+  private[cron] def addNextEventToState(job: CronJob, instant: Instant): Unit = atomic { implicit txn =>
+    executions() = executions() + (job -> Left(instant))
+  }
+
+  private[cron] def addNextExecutionToState(job: CronJob, execution: CronExecution): Unit = atomic { implicit txn =>
+    executions() = executions() + (job -> Right(execution))
+  }
+
+  private def removeJobFromState(job: CronJob): Unit = atomic { implicit txn =>
+    executions() = executions() - job
+  }
+
+  private[cron] def pauseJobs(jobs: Set[CronJob])(implicit user: User): Set[PausedJob] = {
+    val pauseDate = Instant.now()
+    atomic { implicit txn =>
+      val jobsToPause = jobs
+        .filterNot(job => paused().contains(job))
+        .toSeq
+
+      jobsToPause.foreach(removeJobFromState)
+      val justPausedJobs = jobsToPause.map(job => PausedJob(job.id, user, pauseDate))
+      paused() = paused() ++ jobsToPause.zip(justPausedJobs)
+
+      justPausedJobs.toSet
+    }
+  }
+
+  private[cron] def resumeJobs(jobs: Set[CronJob]): Unit = atomic { implicit txn =>
+    paused() = paused() -- jobs
+  }
+
+  private[cron] def snapshot(jobIds: Set[String]) = atomic { implicit txn =>
+    val activeJobsSnapshot = executions().collect {
+      case (cronJob, state) if jobIds.contains(cronJob.id) =>
+        cronJob.asJson
+          .deepMerge(
+            Json.obj(
+              state.fold(
+                "nextInstant" -> _.asJson,
+                "currentExecution" -> _.toExecutionLog(ExecutionStatus.ExecutionRunning).asJson
+              )
+            )
+          )
+          .deepMerge(Json.obj(
+            "status" -> "active".asJson
+          ))
+    }
+    val pausedJobsSnapshot = paused().collect {
+      case (cronJob, pausedJob) if jobIds.contains(cronJob.id) => pausedJob.asJson
+    }
+    val acc = (activeJobsSnapshot ++ pausedJobsSnapshot).toSeq
+    Json.arr(
+      acc: _*
+    )
+  }
+
+  override def toString(): String = {
+    val builder = new StringBuilder()
+    val state = executions.single.get
+    builder.append("\n======State======\n")
+    state.foreach {
+      case (job, jobState) =>
+        val messages = Seq(
+          job.id,
+          jobState.fold(_ toString, e => e.id)
+        )
+        builder.append(messages mkString " :: ")
+        builder.append("\n")
+    }
+    builder.append("======End State======")
+    builder.toString()
   }
 }
 
@@ -52,6 +165,6 @@ case class CronScheduling(cronExpression: String, maxRetry: Int) extends Schedul
   * Class regrouping jobs for scheduler. It doesn't imply any order.
   * @param jobs Jobs to schedule.
   */
-case class CronWorkload(jobs: Set[Job[CronScheduling]]) extends Workload[CronScheduling] {
-  override def all: Set[Job[CronScheduling]] = jobs
+case class CronWorkload(jobs: Set[CronJob]) extends Workload[CronScheduling] {
+  override def all: Set[CronJob] = jobs
 }

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronProject.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronProject.scala
@@ -8,7 +8,7 @@ import io.circe.syntax._
 
 import com.criteo.cuttle._
 import com.criteo.cuttle.ThreadPools._
-import Implicits.serverThreadPool
+import com.criteo.cuttle.ThreadPools.Implicits.serverThreadPool
 import com.criteo.cuttle.Auth.Authenticator
 
 /**
@@ -40,7 +40,7 @@ class CronProject private[cuttle] (val name: String,
     retryStrategy: RetryStrategy = CronProject.retryStrategy
   ): Unit = {
     logger.info("Connecting to database")
-    implicit val transactor = Database.connect(databaseConfig)
+    implicit val transactor = com.criteo.cuttle.Database.connect(databaseConfig)
 
     logger.info("Creating Executor")
     val executor = new Executor[CronScheduling](platforms, transactor, logger, name, version)(retryStrategy)

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronProject.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronProject.scala
@@ -1,0 +1,107 @@
+package com.criteo.cuttle.cron
+
+import scala.concurrent.duration._
+
+import lol.http._
+
+import com.criteo.cuttle._
+import com.criteo.cuttle.ThreadPools._, Implicits.serverThreadPool
+
+/**
+  * A cuttle project is a workflow to execute with the appropriate scheduler.
+  * See the [[CuttleProject]] companion object to create projects.
+  */
+case class CuttleProject[S <: Scheduling] private[cuttle] (name: String,
+                                                           version: String,
+                                                           description: String,
+                                                           env: (String, Boolean),
+                                                           jobs: Workload[S],
+                                                           scheduler: Scheduler[S],
+                                                           routes: PartialService,
+                                                           logger: Logger) {
+
+  /**
+    * Start scheduling and execution with the given environment. It also starts
+    * an HTTP server providing an Web UI and a JSON API.
+    *
+    * @param platforms The configured [[ExecutionPlatform ExecutionPlatforms]] to use to execute jobs.
+    * @param port The port to use for the HTTP daemon.
+    * @param databaseConfig JDBC configuration for MySQL server
+    * @param retryStrategy The strategy to use for execution retry. Default to exponential backoff.
+    */
+  def start(
+    platforms: Seq[ExecutionPlatform] = CuttleProject.defaultPlatforms,
+    port: Int = CuttleProject.port,
+    databaseConfig: DatabaseConfig = CuttleProject.databaseConfig,
+    retryStrategy: RetryStrategy = CuttleProject.retryStrategy
+  ): Unit = {
+    logger.info("Connecting to database")
+    val transactor = Database.connect(databaseConfig)
+
+    logger.info("Creating Executor")
+    val executor = new Executor[S](platforms, transactor, logger, name, version)(retryStrategy)
+
+    logger.info("Scheduler starting workflow")
+    scheduler.start(jobs, executor, transactor, logger)
+
+    logger.info("Starting server")
+    Server.listen(port, onError = { e =>
+      logger.error(e.getMessage)
+      e.printStackTrace()
+      InternalServerError(e.getMessage)
+    })(routes)
+
+    logger.info(s"Listening on http://localhost:$port")
+  }
+
+}
+
+/**
+  * Create new projects using a timeseries scheduler.
+  */
+object CuttleProject {
+
+  /**
+    * Create a new project.
+    * @param name The project name as displayed in the UI.
+    * @param version The project version as displayed in the UI.
+    * @param description The project version as displayed in the UI.
+    * @param env The environment as displayed in the UI (The string is the name while the boolean indicates
+    *            if the environment is a production one).
+    * @param authenticator The way to authenticate HTTP request for the UI and the private API.
+    * @param jobs The workflow to run in this project.
+    * @param scheduler The scheduler instance to use to schedule the Workflow jobs.
+    * @param logger The logger to use to log internal debug informations.
+    */
+  def apply[S <: Scheduling](name: String,
+                             version: String = "",
+                             description: String = "",
+                             env: (String, Boolean) = ("", false),
+                             authenticator: Auth.Authenticator = Auth.GuestAuth)(
+    jobs: Workload[S])(implicit scheduler: Scheduler[S], logger: Logger): CuttleProject[S] = {
+    val cronApp = CronApp()
+    new CuttleProject(name, version, description, env, jobs, scheduler, cronApp.routes, logger)
+  }
+
+  private[CuttleProject] val defaultPlatforms: Seq[ExecutionPlatform] = {
+    import java.util.concurrent.TimeUnit.SECONDS
+
+    import platforms._
+
+    Seq(
+      local.LocalPlatform(
+        maxForkedProcesses = 10
+      ),
+      http.HttpPlatform(
+        maxConcurrentRequests = 10,
+        rateLimits = Seq(
+          ".*" -> http.HttpPlatform.RateLimit(1, per = SECONDS)
+        )
+      )
+    )
+  }
+
+  private[CuttleProject] val port = 8888
+  private[CuttleProject] val databaseConfig = DatabaseConfig.fromEnv
+  private[CuttleProject] val retryStrategy = RetryStrategy.SimpleRetryStategy(1.minute)
+}

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronScheduler.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronScheduler.scala
@@ -1,13 +1,14 @@
 package com.criteo.cuttle.cron
 
-import java.time.Instant
-
+import scala.concurrent.stm.Txn.ExternalDecider
+import scala.concurrent.stm._
 import cats.effect.IO
 import cats.implicits._
+import doobie.implicits._
+import io.circe.Json
+
 import com.criteo.cuttle._
 import com.criteo.cuttle.utils.Timeout
-
-import scala.concurrent.stm.{Ref, _}
 
 /** A [[CronScheduler]] executes the set of Jobs at the time instants defined by Cron expressions.
   * Each [[com.criteo.cuttle.Job Job]] has it's own expression and executed separately from others.
@@ -24,71 +25,108 @@ import scala.concurrent.stm.{Ref, _}
   * we can't produce the next computing instant from Cron expression.
   */
 case class CronScheduler(logger: Logger) extends Scheduler[CronScheduling] {
-  private type CronExecution = Execution[CronScheduling]
-
-  type CronJob = Job[CronScheduling]
 
   override val name = "cron"
 
-  private val _state = Ref(Map.empty[CronJob, Either[Instant, CronExecution]])
+  private val queries = new Queries {}
+  private val state = CronState(logger)
 
-  private def addNextEventToState(job: CronJob, instant: Instant) = IO {
-    atomic { implicit txn =>
-      _state() = _state() + (job -> Either.left(instant))
-    }
-  }
+  private def logState = IO(logger.debug(state.toString()))
 
-  private def addNextExecutionToState(job: CronJob, execution: CronExecution) = IO {
-    atomic { implicit txn =>
-      _state() = _state() + (job -> Either.right(execution))
-    }
-  }
+  private def externalDecider[A](dbConnection: doobie.ConnectionIO[A])(implicit transactor: XA, txn: InTxnEnd): Unit =
+    Txn.setExternalDecider(new ExternalDecider {
+      def shouldCommit(implicit txn: InTxnEnd): Boolean = {
+        dbConnection.transact(transactor).unsafeRunSync
+        true
+      }
+    })
 
-  private def logState() = IO {
-    val state = _state.single.get
-    logger.debug("======State======")
-    state.foreach {
-      case (job, jobState) =>
-        val messages = Seq(
-          job.id,
-          jobState.fold(_ toString, e => e.id)
-        )
-        logger.debug(messages mkString " :: ")
-    }
-    logger.debug("======End State======")
-  }
+  private[cron] def getPausedJobs = state.getPausedJobs()
 
-  override def start(workload: Workload[CronScheduling],
-                     executor: Executor[CronScheduling],
-                     xa: XA,
-                     logger: Logger = logger): Unit = {
+  private[cron] def pauseJobs(jobs: Set[CronJob], executor: Executor[CronScheduling])(implicit transactor: XA,
+                                                                                      user: Auth.User): Unit = {
+    logger.debug(s"Pausing jobs $jobs")
+    val cancelableExecutions = atomic { implicit tx =>
+      val jobsToPause = state.pauseJobs(jobs)
 
-    def runAndRetry(job: Job[CronScheduling], scheduledAt: ScheduledAt, retryNum: Int): IO[Completed] = {
-      val runIO = for {
-        runInfo <- IO {
-          logger.debug(s"Sending job ${job.id} to executor")
-          val cronContext = CronContext(scheduledAt.instant)(retryNum)
-          executor.run(job, cronContext)
-        }
-        _ <- addNextExecutionToState(job, runInfo._1)
-        _ <- logState()
-        completed <- IO.fromFuture(IO(runInfo._2))
-      } yield completed
+      if (jobsToPause.isEmpty) Left(Seq.empty)
+      else {
+        val pauseQuery = jobsToPause.map(queries.pauseJob).reduceLeft(_ *> _)
+        externalDecider(pauseQuery)
 
-      runIO.recoverWith {
-        case e: Throwable =>
-          if (retryNum < job.scheduling.maxRetry) {
-            val nextRetry = retryNum + 1
-            logger.debug(s"Job ${job.id} has failed it's going to be retried. Retry number: $nextRetry")
-            runAndRetry(job, scheduledAt, nextRetry)
-          } else {
-            logger.debug(s"Job ${job.id} has reached the maximum number of retries")
-            IO.raiseError(e)
-          }
+        Right(jobsToPause.flatMap { toPause =>
+          logger.debug(s"Retrieve executions to pause for $toPause")
+          executor.runningState.filterKeys(_.job.id == toPause.id).keys ++ executor.throttledState
+            .filterKeys(_.job.id == toPause.id)
+            .keys
+        })
       }
     }
 
-    def run(job: CronJob): IO[Completed] = {
+    cancelableExecutions match {
+      case Left(_) => ()
+      case Right(executions) =>
+        logger.debug(s"Canceling ${executions.size} executions")
+        executions.foreach { execution =>
+          execution.streams.debug(s"Job has been paused by user ${user.userId}")
+          execution.cancel()
+        }
+    }
+  }
+
+  private[cron] def resumeJobs(jobs: Set[Job[CronScheduling]],
+                               executor: Executor[CronScheduling])(implicit transactor: XA, user: Auth.User): Unit = {
+    logger.debug(s"Resuming jobs $jobs")
+    val jobIdsToResume = jobs.map(_.id)
+    val resumeQuery = jobIdsToResume.map(queries.resumeJob).reduceLeft(_ *> _)
+
+    atomic { implicit tx =>
+      externalDecider(resumeQuery)
+      state.resumeJobs(jobs)
+    }
+    val programs = jobs.map { job =>
+      logger.debug(s"Activating job $job")
+      run(job, executor)
+    }
+
+    logger.info(s"Relaunching jobs $jobs")
+    unsafeRunAsync(programs)
+  }
+
+  private def run(job: CronJob, executor: Executor[CronScheduling]): IO[Completed] = {
+    def runAndRetry(job: Job[CronScheduling], scheduledAt: ScheduledAt, retryNum: Int): IO[Completed] =
+      // don't run anything when job is paused
+      if (state.isPaused(job)) {
+        IO.pure(Completed)
+      } else {
+        val runIO = for {
+          runInfo <- IO {
+            logger.debug(s"Sending job ${job.id} to executor")
+            val cronContext = CronContext(scheduledAt.instant)(retryNum)
+            executor.run(job, cronContext)
+          }
+          _ <- IO(state.addNextExecutionToState(job, runInfo._1))
+          _ <- logState
+          completed <- IO.fromFuture(IO(runInfo._2))
+        } yield completed
+
+        runIO.recoverWith {
+          case e: Throwable =>
+            if (retryNum < job.scheduling.maxRetry) {
+              val nextRetry = retryNum + 1
+              logger.debug(s"Job ${job.id} has failed it's going to be retried. Retry number: $nextRetry")
+              runAndRetry(job, scheduledAt, nextRetry)
+            } else {
+              logger.debug(s"Job ${job.id} has reached the maximum number of retries")
+              IO.raiseError(e)
+            }
+        }
+      }
+
+    // don't run anything when job is paused
+    if (state.isPaused(job)) {
+      IO.pure(Completed)
+    } else {
       val runIO = for {
         maybeScheduledAt <- IO.pure(job.scheduling.nextEvent())
         completed <- maybeScheduledAt match {
@@ -100,11 +138,11 @@ case class CronScheduler(logger: Logger) extends Scheduler[CronScheduling] {
           case Some(scheduledAt) =>
             logger.debug(s"Run job ${job.id} at ${scheduledAt.instant} with a delay of ${scheduledAt.delay}")
             for {
-              _ <- addNextEventToState(job, scheduledAt.instant)
-              _ <- logState()
+              _ <- IO(state.addNextEventToState(job, scheduledAt.instant))
+              _ <- logState
               _ <- Timeout.applyF(scheduledAt.delay)
               _ <- runAndRetry(job, scheduledAt, 0)
-              completed <- run(job)
+              completed <- run(job, executor)
             } yield completed
         }
       } yield completed
@@ -117,17 +155,32 @@ case class CronScheduler(logger: Logger) extends Scheduler[CronScheduling] {
           throw new Exception(message)
       }
     }
+  }
+
+  private def unsafeRunAsync(programs: Set[IO[Completed]]) = {
+    import ThreadPools.Implicits.cronContextShift
+    programs.toList.parSequence.unsafeRunAsyncAndForget()
+  }
+
+  override def getStats(jobIds: Set[String]): Json = state.snapshot(jobIds)
+
+  override def start(workload: Workload[CronScheduling],
+                     executor: Executor[CronScheduling],
+                     xa: XA,
+                     logger: Logger = logger): Unit = {
+    logger.info("Getting paused jobs")
+    val pausedJob = queries.getPausedJobs.transact(xa).unsafeRunSync()
 
     val programs = workload match {
       case CronWorkload(jobs) =>
+        logger.info("Init Cron State")
+        state.init(jobs, pausedJob)
         logger.info(s"Building IOs for Cron Workload with ${jobs.size} job(s)")
-        jobs.map(run)
+        jobs.map(job => run(job, executor))
     }
 
     // running all jobs asynchronously
-    logger.info(s"Running Cron Workload")
-    import ThreadPools.Implicits.cronContextShift
-    programs.toList.parSequence.unsafeRunSync
-    logger.info(s"Stopping Cron Workload")
+    logger.info(s"Launching Cron Workload")
+    unsafeRunAsync(programs)
   }
 }

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronScheduler.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronScheduler.scala
@@ -4,8 +4,6 @@ import java.time.Instant
 
 import cats.effect.IO
 import cats.implicits._
-import com.criteo.cuttle.ThreadPools.Implicits.sideEffectThreadPool
-import com.criteo.cuttle.ThreadPools._
 import com.criteo.cuttle._
 import com.criteo.cuttle.utils.Timeout
 
@@ -128,6 +126,8 @@ case class CronScheduler(logger: Logger) extends Scheduler[CronScheduling] {
 
     // running all jobs asynchronously
     logger.info(s"Running Cron Workload")
-    programs.foreach(_.unsafeRunAsync(_ => ()))
+    import ThreadPools.Implicits.cronContextShift
+    programs.toList.parSequence.unsafeRunSync
+    logger.info(s"Stopping Cron Workload")
   }
 }

--- a/cron/src/main/scala/com/criteo/cuttle/cron/Database.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/Database.scala
@@ -1,0 +1,14 @@
+package com.criteo.cuttle.cron
+
+import java.time.Instant
+
+import doobie.util.fragment.Fragment
+import doobie.implicits._
+
+private[cron] object Database {
+  def sqlGetContextsBetween(start: Instant, end: Instant): Fragment =
+    sql"""
+      SELECT context_id as id, context_id as json FROM executions
+      WHERE (start_time >= ${start} and start_time <= ${end}) or (end_time >= ${start} and end_time <= ${end})
+    """
+}

--- a/cron/src/main/scala/com/criteo/cuttle/cron/package.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/package.scala
@@ -1,0 +1,6 @@
+package com.criteo.cuttle
+
+package object cron {
+  type CronJob = Job[CronScheduling]
+  type CronExecution = Execution[CronScheduling]
+}

--- a/cron/src/main/scala/com/criteo/cuttle/cron/package.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/package.scala
@@ -1,6 +1,31 @@
 package com.criteo.cuttle
 
+import java.util.concurrent.atomic.AtomicInteger
+
+import cats.effect.IO
+import com.criteo.cuttle.ThreadPools._
+import com.criteo.cuttle.ThreadPools.ThreadPoolSystemProperties._
+
+import scala.concurrent.ExecutionContext
+
 package object cron {
   type CronJob = Job[CronScheduling]
   type CronExecution = Execution[CronScheduling]
+
+  object Implicits {
+    // Thread pool to run Cron scheduler
+    implicit val cronThreadPool = new WrappedThreadPool with Metrics {
+      private val _threadPoolSize: AtomicInteger = new AtomicInteger(0)
+
+      override val underlying = ExecutionContext.fromExecutorService(
+        newFixedThreadPool(fromSystemProperties(CronThreadCount, Runtime.getRuntime.availableProcessors),
+                           poolName = Some("Cron"),
+                           threadCounter = _threadPoolSize)
+      )
+
+      override def threadPoolSize(): Int = _threadPoolSize.get()
+    }
+
+    implicit val cronContextShift = IO.contextShift(cronThreadPool.underlying)
+  }
 }


### PR DESCRIPTION
MVP of Cron Scheduler API.
    
    Main features:
    - CronApp class with minimalistic public and private API was created,
    supported API is listed under https://documenter.getpostman.com/view/3548308/RznCs12X
    Briefly we can see a status of a job, list job executions, see execution's logs and
    pause/resume a job.
    - CronProject takes care of instantiation of db connection, executor, scheduler
    and CronApp API server
    - HelloCronScheduling example was updated accordingly, check it out!
    
    Others:
    - introducing thread pool for Cron
    - sse method moved to global cuttle utils package object
    - state of CronScheduler became a separate class with methods which allow atomic mutation of 
    underlying stm
    - some scalafmt was applied to TimeSeriesApp