### PR TITLE
fix cron loop halt when reaching the maximum number of retries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val devMode = settingKey[Boolean]("Some build optimization are applied in devMode.")
 val writeClasspath = taskKey[File]("Write the project classpath to a file.")
 
-val VERSION = "0.5.1"
+val VERSION = "0.5.2"
 
 lazy val catsCore = "1.5.0"
 lazy val circe = "0.10.1"

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronScheduler.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronScheduler.scala
@@ -127,7 +127,7 @@ case class CronScheduler(logger: Logger) extends Scheduler[CronScheduling] {
               runAndRetry(job, scheduledAt, nextRetry)
             } else {
               logger.debug(s"Job ${job.id} has reached the maximum number of retries")
-              IO.raiseError(e)
+              IO.pure(Completed)
             }
         }
       }


### PR DESCRIPTION
- Cron scheduling loop stopped when a job reached the maximum number of retries,
now it fixed by completing the scheduling window
- CronContext has been made public as it needs to be used by clients