### PR TITLE
Configurable logs & timeseries state retention

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Database.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Database.scala
@@ -2,6 +2,7 @@ package com.criteo.cuttle
 
 import java.time._
 import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.{Duration => ScalaDuration}
 
 import scala.util._
 
@@ -351,6 +352,15 @@ private[cuttle] case class Queries(logger: Logger) {
     sql"""
       INSERT INTO executions_streams (id, streams) VALUES
       (${id}, ${streams})
+    """.update.run
+
+  def applyLogsRetention(logsRetention: ScalaDuration): ConnectionIO[Int] =
+    sql"""
+      DELETE es
+        FROM executions_streams es
+        JOIN executions e
+          ON es.id = e.id
+       WHERE end_time < ${Instant.now.minusSeconds(logsRetention.toSeconds)}
     """.update.run
 
   def archivedStreams(id: String): ConnectionIO[Option[String]] =

--- a/core/src/main/scala/com/criteo/cuttle/ExecutionStreams.scala
+++ b/core/src/main/scala/com/criteo/cuttle/ExecutionStreams.scala
@@ -149,11 +149,17 @@ private[cuttle] object ExecutionStreams {
     logFile(id).delete()
   }
 
-  def archive(id: ExecutionId, queries: Queries, xa: XA): Unit = {
-    queries
-      .archiveStreams(id, streamsAsString(id).getOrElse(sys.error(s"Cannot archive streams for execution $id")))
-      .transact(xa)
-      .unsafeRunSync()
+  def archive(id: ExecutionId, queries: Queries, logsRetention: Option[Duration], xa: XA): Unit = {
+    (for {
+      _ <-
+        queries
+          .archiveStreams(id, streamsAsString(id).getOrElse(sys.error(s"Cannot archive streams for execution $id")))
+          .transact(xa)
+      _ <-
+        logsRetention.map { retention =>
+          queries.applyLogsRetention(retention).transact(xa)
+        }.getOrElse(IO.unit)
+    } yield ()).unsafeRunSync()
     discard(id)
   }
 }

--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{Timer, TimerTask}
 
 import scala.concurrent.duration._
+import scala.concurrent.duration.{Duration => ScalaDuration}
 import scala.concurrent.stm._
 import scala.concurrent.{Future, Promise}
 import scala.reflect.{ClassTag, classTag}
@@ -411,7 +412,8 @@ class Executor[S <: Scheduling] private[cuttle] (val platforms: Seq[ExecutionPla
                                                  xa: XA,
                                                  logger: Logger,
                                                  val projectName: String,
-                                                 val projectVersion: String)(implicit retryStrategy: RetryStrategy)
+                                                 val projectVersion: String,
+                                                 logsRetention: Option[ScalaDuration] = None)(implicit retryStrategy: RetryStrategy)
     extends MetricProvider[S] {
 
   import ExecutionStatus._
@@ -723,7 +725,7 @@ class Executor[S <: Scheduling] private[cuttle] (val platforms: Seq[ExecutionPla
         .andThen {
           case result =>
             try {
-              ExecutionStreams.archive(execution.id, queries, xa)
+              ExecutionStreams.archive(execution.id, queries, logsRetention, xa)
             } catch {
               case e: Throwable =>
                 e.printStackTrace()

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronProject.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronProject.scala
@@ -32,18 +32,20 @@ class CronProject private[cuttle] (val name: String,
     * @param port           The port to use for the HTTP daemon.
     * @param databaseConfig JDBC configuration for MySQL server
     * @param retryStrategy  The strategy to use for execution retry. Default to exponential backoff.
+    * @param logsRetention  If specified, automatically clean the execution logs older than the given duration.
     */
   def start(
     platforms: Seq[ExecutionPlatform] = CronProject.defaultPlatforms,
     port: Int = CronProject.port,
     databaseConfig: DatabaseConfig = CronProject.databaseConfig,
-    retryStrategy: RetryStrategy = CronProject.retryStrategy
+    retryStrategy: RetryStrategy = CronProject.retryStrategy,
+    logsRetention: Option[Duration] = None
   ): Unit = {
     logger.info("Connecting to database")
     implicit val transactor = com.criteo.cuttle.Database.connect(databaseConfig)(logger)
 
     logger.info("Creating Executor")
-    val executor = new Executor[CronScheduling](platforms, transactor, logger, name, version)(retryStrategy)
+    val executor = new Executor[CronScheduling](platforms, transactor, logger, name, version, logsRetention)(retryStrategy)
 
     logger.info("Scheduler starting workflow")
     scheduler.start(workload, executor, transactor, logger)

--- a/examples/src/main/scala/com/criteo/cuttle/examples/HelloTimeSeries.scala
+++ b/examples/src/main/scala/com/criteo/cuttle/examples/HelloTimeSeries.scala
@@ -119,6 +119,6 @@ object HelloTimeSeries {
       world dependsOn (hello1 and hello2 and hello3)
     }.
     // Starts the scheduler and an HTTP server.
-    start()
+    start(logsRetention = Some(1.minute))
   }
 }

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -35,7 +35,7 @@ private[timeseries] object TimeSeriesApp {
         "name" -> project.name.asJson,
         "version" -> Option(project.version).filterNot(_.isEmpty).asJson,
         "description" -> Option(project.description).filterNot(_.isEmpty).asJson,
-        "scheduler" -> project.scheduler.name.asJson,
+        "scheduler" -> "timeseries".asJson,
         "env" -> Json.obj(
           "name" -> Option(project.env._1).filterNot(_.isEmpty).asJson,
           "critical" -> project.env._2.asJson
@@ -85,9 +85,9 @@ private[timeseries] object TimeSeriesApp {
 
 }
 
-private[timeseries] case class TimeSeriesApp(project: CuttleProject, executor: Executor[TimeSeries], xa: XA) {
+private[timeseries] case class TimeSeriesApp(project: CuttleProject, executor: Executor[TimeSeries], scheduler: TimeSeriesScheduler, xa: XA) {
 
-  import project.{jobs, scheduler}
+  import project.{jobs}
 
   import JobState._
   import TimeSeriesApp._

--- a/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSchedulerIntegrationTests.scala
+++ b/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesSchedulerIntegrationTests.scala
@@ -43,7 +43,7 @@ object TimeSeriesSchedulerIntegrationTests {
     val executor =
       new Executor[TimeSeries](Seq(LocalPlatform(maxForkedProcesses = 10)), xa, logger, project.name, project.version)(
         retryImmediatelyStrategy)
-    val scheduler = project.scheduler
+    val scheduler = new TimeSeriesScheduler(logger)
 
     scheduler.initialize(project.jobs, xa, logger)
 


### PR DESCRIPTION
Refactoring how the TimeSeriesScheduler is instantiated (it was
a typeclass on Scheduling before but now we don't need to retrieve
the instance implicitely).

Also cleaning the code duplication between CuttleProject.start &
CuttleProject.build