### PR TITLE
Fix scrolling issues in Firefox and Chrome 72+

### DIFF
--- a/timeseries/src/main/javascript/app/components/StreamView.js
+++ b/timeseries/src/main/javascript/app/components/StreamView.js
@@ -107,6 +107,7 @@ const styles = {
     display: "flex",
     background: "#23252f",
     position: "relative",
+    minHeight: "0",
 
     "& ul": {
       flex: "1",

--- a/timeseries/src/main/javascript/app/pages/Backfills.js
+++ b/timeseries/src/main/javascript/app/pages/Backfills.js
@@ -252,7 +252,8 @@ const styles = {
     flex: "1",
     display: "flex",
     flexDirection: "column",
-    position: "relative"
+    position: "relative",
+    minHeight: 0
   },
   title: {
     fontSize: "1.2em",

--- a/timeseries/src/main/javascript/app/pages/CalendarFocus.js
+++ b/timeseries/src/main/javascript/app/pages/CalendarFocus.js
@@ -671,7 +671,8 @@ const styles = {
     flex: "1",
     display: "flex",
     flexDirection: "column",
-    position: "relative"
+    position: "relative",
+    minHeight: "0"
   },
   title: {
     fontSize: "1.2em",
@@ -722,7 +723,8 @@ const styles = {
     boxShadow: "0px 1px 2px #BECBD6",
     flex: "1",
     display: "flex",
-    flexDirection: "column"
+    flexDirection: "column",
+    minHeight: "0"
   },
   axis: {
     "& path.domain, & line": {

--- a/timeseries/src/main/javascript/app/pages/Jobs.js
+++ b/timeseries/src/main/javascript/app/pages/Jobs.js
@@ -332,7 +332,8 @@ const styles = {
     flex: "1",
     display: "flex",
     flexDirection: "column",
-    position: "relative"
+    position: "relative",
+    minHeight: "0"
   },
   title: {
     fontSize: "1.2em",


### PR DESCRIPTION
- Chrome 72 now adheres to the css-flexbox spec and sets a non-zero
min-height for containers, which causes issues with scrolling, see
the spec at https://drafts.csswg.org/css-flexbox/#min-size-auto
- Fix executions logs not being scrollable anymore
- Fix calendar focus and job views scrolling the whole page instead of
only the job list there are too many jobs
- Fix backfill view scrolling the whole page when there are too many
backfills