### PR TITLE
Pause/Resume Jobs

### DIFF
--- a/timeseries/src/main/javascript/App.js
+++ b/timeseries/src/main/javascript/App.js
@@ -16,7 +16,7 @@ import * as Actions from "./actions";
 import Calendar from "./app/pages/Calendar";
 import CalendarFocus from "./app/pages/CalendarFocus";
 import Workflow from "./app/pages/Workflow";
-import { Started, Stuck, Paused, Finished } from "./app/pages/ExecutionLogs";
+import { Started, Stuck, Finished } from "./app/pages/ExecutionLogs";
 import Execution from "./app/pages/Execution";
 import TimeSeriesExecutions from "./app/pages/TimeSeriesExecutions";
 import Backfill from "./app/pages/Backfill";
@@ -82,8 +82,6 @@ class App extends React.Component<Props> {
             return <Started />;
           case "executions/stuck":
             return <Stuck />;
-          case "executions/paused":
-            return <Paused />;
           case "executions/finished":
             return <Finished />;
           case "executions/detail":

--- a/timeseries/src/main/javascript/ApplicationState.js
+++ b/timeseries/src/main/javascript/ApplicationState.js
@@ -35,12 +35,6 @@ export type Page =
       order?: "asc" | "desc"
     }
   | {
-      id: "executions/paused",
-      page?: number,
-      sort?: string,
-      order?: "asc" | "desc"
-    }
-  | {
       id: "executions/finished",
       page?: number,
       sort?: string,

--- a/timeseries/src/main/javascript/app/pages/ExecutionLogs.js
+++ b/timeseries/src/main/javascript/app/pages/ExecutionLogs.js
@@ -495,37 +495,9 @@ export const Started = connect(mapStateToProps, mapDispatchToProps)(
       selectedJobs,
       envCritical
     }) => {
-      const isFilterApplied = selectedJobs.length > 0;
-
-      const menuItems = [];
-      if (isFilterApplied) {
-        //TODO pass jobs through body
-        const selectedJobsString = selectedJobs.join(",");
-        const pauseFiltered = () =>
-          fetch(`/api/jobs/pause?jobs=${selectedJobsString}`, {
-            method: "POST",
-            credentials: "include"
-          });
-
-        menuItems.push(
-          <span onClick={pauseFiltered}>{`Pause ${
-            selectedJobs.length
-          } filtered jobs`}</span>
-        );
-      } else {
-        const pauseAll = () =>
-          fetch("/api/jobs/pause", {
-            method: "POST",
-            credentials: "include"
-          });
-
-        menuItems.push(<span onClick={pauseAll}>{"Pause everything"}</span>);
-      }
-
       return (
         <div className={classes.container}>
           <h1 className={classes.title}>Started executions</h1>
-          <PopoverMenu className={classes.menu} items={menuItems} />
           <ExecutionLogs
             envCritical={envCritical}
             classes={classes}
@@ -543,75 +515,6 @@ export const Started = connect(mapStateToProps, mapDispatchToProps)(
               };
             }}
             label="started"
-            sort={{ column: sort || "context", order: order || "asc" }}
-            selectedJobs={selectedJobs}
-          />
-        </div>
-      );
-    }
-  )
-);
-
-export const Paused = connect(mapStateToProps, mapDispatchToProps)(
-  injectSheet(styles)(
-    ({
-      classes,
-      workflow,
-      page,
-      sort,
-      order,
-      open,
-      selectedJobs,
-      envCritical
-    }) => {
-      const isFilterApplied = selectedJobs.length > 0;
-
-      const menuItems = [];
-      if (isFilterApplied) {
-        //TODO pass jobs through body
-        const selectedJobsString = selectedJobs.join(",");
-        const resumeFiltered = () =>
-          fetch(`/api/jobs/resume?jobs=${selectedJobsString}`, {
-            method: "POST",
-            credentials: "include"
-          });
-
-        menuItems.push(
-          <span onClick={resumeFiltered}>{`Resume ${
-            selectedJobs.length
-          } filtered jobs`}</span>
-        );
-      } else {
-        const resumeAll = () =>
-          fetch("/api/jobs/resume", {
-            method: "POST",
-            credentials: "include"
-          });
-
-        menuItems.push([<span onClick={resumeAll}>Resume everything</span>]);
-      }
-
-      return (
-        <div className={classes.container}>
-          <h1 className={classes.title}>Paused executions</h1>
-          <PopoverMenu className={classes.menu} items={menuItems} />
-          <ExecutionLogs
-            envCritical={envCritical}
-            classes={classes}
-            open={open}
-            page={page}
-            workflow={workflow}
-            columns={["job", "context", "status", "detail"]}
-            request={(page, rowsPerPage, sort) => {
-              return {
-                endpoint: "/api/executions/status/paused",
-                jobs: selectedJobs,
-                sort: sort,
-                limit: rowsPerPage,
-                offset: page * rowsPerPage
-              };
-            }}
-            label="paused"
             sort={{ column: sort || "context", order: order || "asc" }}
             selectedJobs={selectedJobs}
           />

--- a/timeseries/src/main/javascript/app/pages/Jobs.js
+++ b/timeseries/src/main/javascript/app/pages/Jobs.js
@@ -7,6 +7,8 @@ import { compose } from "redux";
 import { navigate } from "redux-url";
 import { displayFormat } from "../utils/Date";
 import OpenIcon from "react-icons/lib/md/zoom-in";
+import ResumeIcon from "react-icons/lib/md/play-arrow";
+import PauseIcon from "react-icons/lib/md/pause";
 import Spinner from "../components/Spinner";
 import Table from "../components/Table";
 import Link from "../components/Link";
@@ -14,6 +16,7 @@ import { Badge } from "../components/Badge";
 import type { JobStatus } from "../../ApplicationState";
 import PopoverMenu from "../components/PopoverMenu";
 import isEqual from "lodash/isEqual";
+import classNames from "classnames";
 
 type Props = {
   classes: any,
@@ -189,25 +192,6 @@ const activeJobsProps = {
   status: "active"
 };
 
-const jobMenu = ({
-  persist,
-  job,
-  status,
-  classes
-}: {
-  persist: any,
-  job: string,
-  status: string,
-  classes: any
-}) => {
-  const menuItems =
-    status === "paused"
-      ? [<span onClick={jobAction("resume", job, persist)}>Resume</span>]
-      : [<span onClick={jobAction("pause", job, persist)}>Pause</span>];
-
-  return <PopoverMenu className={classes.menu} items={menuItems} />;
-};
-
 class JobsComp extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -281,12 +265,23 @@ class JobsComp extends React.Component<Props, State> {
                     </Link>
                   );
                 case "actions":
-                  return jobMenu({
-                    persist: persist,
-                    job: row.id,
-                    status: row.status,
-                    classes
-                  });
+                  return row.status === "paused" ? (
+                    <a
+                      onClick={jobAction("resume", row.id, persist)}
+                      className={classNames(classes.link, classes.actionIcon)}
+                      title="Resume"
+                    >
+                      <ResumeIcon />
+                    </a>
+                  ) : (
+                    <a
+                      onClick={jobAction("pause", row.id, persist)}
+                      className={classNames(classes.link, classes.actionIcon)}
+                      title="Pause"
+                    >
+                      <PauseIcon />
+                    </a>
+                  );
                 default:
                   return column2Comp[column](row);
               }
@@ -392,6 +387,13 @@ const styles = {
     paddingBottom: "15%"
   },
   openIcon: {
+    fontSize: "22px",
+    color: "#607e96",
+    padding: "15px",
+    margin: "-15px"
+  },
+  actionIcon: {
+    cursor: "pointer",
     fontSize: "22px",
     color: "#607e96",
     padding: "15px",

--- a/timeseries/src/main/javascript/app/pages/Jobs.js
+++ b/timeseries/src/main/javascript/app/pages/Jobs.js
@@ -157,11 +157,13 @@ const fetchPausedJobs = (
     .then(persist);
 };
 
-const jobAction = (action, job, persist) => {
-  return fetch(`/api/jobs/${action}?jobs=${job}`, {
-    method: "POST",
-    credentials: "include"
-  }).then(() => fetchPausedJobs(persist));
+const jobAction = (action, jobs, persist) => {
+  return () =>
+    fetch(`/api/jobs/${action}`, {
+      method: "POST",
+      credentials: "include",
+      body: JSON.stringify({ jobs: jobs })
+    }).then(() => fetchPausedJobs(persist));
 };
 
 const NoJobs = ({
@@ -200,8 +202,8 @@ const jobMenu = ({
 }) => {
   const menuItems =
     status === "paused"
-      ? [<span onClick={() => jobAction("resume", job, persist)}>Resume</span>]
-      : [<span onClick={() => jobAction("pause", job, persist)}>Pause</span>];
+      ? [<span onClick={jobAction("resume", job, persist)}>Resume</span>]
+      : [<span onClick={jobAction("pause", job, persist)}>Pause</span>];
 
   return <PopoverMenu className={classes.menu} items={menuItems} />;
 };
@@ -227,9 +229,11 @@ class JobsComp extends React.Component<Props, State> {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    return !isEqual(this.props, nextProps) ||
-        !isEqual(this.state.data, nextState.data) ||
-        !isEqual(this.state.pausedJobs, nextState.pausedJobs);
+    return (
+      !isEqual(this.props, nextProps) ||
+      !isEqual(this.state.data, nextState.data) ||
+      !isEqual(this.state.pausedJobs, nextState.pausedJobs)
+    );
   }
 
   render() {
@@ -308,9 +312,28 @@ class JobsComp extends React.Component<Props, State> {
       }
     };
 
+    const jobs = selectedJobs.join(",");
+    const persist = this.setState.bind(this);
+    const pause = jobAction("pause", jobs, persist);
+    const resume = jobAction("resume", jobs, persist);
+    const isFilterApplied = selectedJobs.length > 0;
+    const menuItems = [];
+    if (isFilterApplied) {
+      menuItems.push(
+        <span onClick={pause}>Pause {selectedJobs.length} filtered jobs</span>,
+        <span onClick={resume}>Resume {selectedJobs.length} filtered jobs</span>
+      );
+    } else {
+      menuItems.push(
+        <span onClick={pause}>Pause everything</span>,
+        <span onClick={resume}>Resume everything</span>
+      );
+    }
+
     return (
       <div className={classes.container}>
         <h1 className={classes.title}>Jobs</h1>
+        <PopoverMenu className={classes.menu} items={menuItems} />
         <div className={classes.grid}>
           <div className={classes.data}>
             <Data />

--- a/timeseries/src/main/javascript/index.js
+++ b/timeseries/src/main/javascript/index.js
@@ -29,8 +29,6 @@ const routes = {
     openPage({ id: "executions/stuck", page, sort, order }),
   "/executions/finished": (_, { page, sort, order }) =>
     openPage({ id: "executions/finished", page, sort, order }),
-  "/executions/paused": (_, { page, sort, order }) =>
-    openPage({ id: "executions/paused", page, sort, order }),
   "/executions/:id": ({ id }) =>
     openPage({ id: "executions/detail", execution: id }),
   "/workflow/*": ({ _ }, { showDetail, refPath }) =>

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -284,18 +284,24 @@ private[timeseries] case class TimeSeriesApp(project: CuttleProject,
       Ok
     }
 
-    case POST at url"/api/jobs/pause?jobs=$jobs" => { implicit user =>
-      getJobsOrNotFound(jobs).fold(IO.pure, jobs => {
-        scheduler.pauseJobs(jobs, executor, xa)
-        Ok
-      })
+    case request @ POST at url"/api/jobs/pause" => { implicit user =>
+      request.readAs[Json].flatMap { json =>
+        val jobs = json.hcursor.get[String]("jobs").getOrElse("")
+        getJobsOrNotFound(jobs).fold(IO.pure, jobs => {
+          scheduler.pauseJobs(jobs, executor, xa)
+          Ok
+        })
+      }
     }
 
-    case POST at url"/api/jobs/resume?jobs=$jobs" => { implicit user =>
-      getJobsOrNotFound(jobs).fold(IO.pure, jobs => {
-        scheduler.resumeJobs(jobs, xa)
-        Ok
-      })
+    case request @ POST at url"/api/jobs/resume" => { implicit user =>
+      request.readAs[Json].flatMap { json =>
+        val jobs = json.hcursor.get[String]("jobs").getOrElse("")
+        getJobsOrNotFound(jobs).fold(IO.pure, jobs => {
+          scheduler.resumeJobs(jobs, xa)
+          Ok
+        })
+      }
     }
     case POST at url"/api/jobs/all/unpause" => { implicit user =>
       scheduler.resumeJobs(jobs.all, xa)


### PR DESCRIPTION
During the creation of the Jobs screen, the previous Paused executions Screen has been removed from UI. It included the Resume All/Filtered jobs feature.
This PR does:
- Remove Paused executions dead code
- Moves Pause/Resume All/Filtered jobs action to the Jobs Screen