### PR TITLE
add previous failures to execution object

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val devMode = settingKey[Boolean]("Some build optimization are applied in devMode.")
 val writeClasspath = taskKey[File]("Write the project classpath to a file.")
 
-val VERSION = "0.7.0"
+val VERSION = "0.8.0"
 
 lazy val catsCore = "1.5.0"
 lazy val circe = "0.10.1"

--- a/core/src/test/scala/com/criteo/cuttle/ExecutorSpec.scala
+++ b/core/src/test/scala/com/criteo/cuttle/ExecutorSpec.scala
@@ -118,7 +118,8 @@ class ExecutorSpec extends FunSuite with TestScheduling {
       },
       platforms = Seq.empty,
       "project_name",
-      "test_version"
+      "test_version",
+      List.empty
     )
 
   private val fooTag = Tag("foo")

--- a/examples/src/main/scala/com/criteo/cuttle/examples/HelloTimeSeries.scala
+++ b/examples/src/main/scala/com/criteo/cuttle/examples/HelloTimeSeries.scala
@@ -77,6 +77,7 @@ object HelloTimeSeries {
           tags = Set(Tag("hello"), Tag("unsafe"))) { implicit e =>
         // Here we mix a Scala code execution and a sh script execution.
         e.streams.info("Hello 3 from an unsafe job")
+        e.streams.info(s"My previous failures are ${e.previousFailures}")
         val completed = exec"sleep 3" ()
 
         completed.map { _ =>


### PR DESCRIPTION
previous failures are available on execution object in order to enable users to stop their jobs based on the run history