### PR TITLE
Fix a backfill issue for job ids containing a comma

### DIFF
--- a/timeseries/src/main/javascript/app/menu/MenuHeader.js
+++ b/timeseries/src/main/javascript/app/menu/MenuHeader.js
@@ -25,7 +25,9 @@ const MenuHeader = ({
   projectVersion
 }: Props) => (
   <Link className={classNames(classes.main, className)} href="/">
-    <span title={projectName} className={classes.projectName}>{projectName}</span>
+    <span title={projectName} className={classes.projectName}>
+      {projectName}
+    </span>
     {projectVersion && (
       <span className={classes.projectVersion}>{projectVersion}</span>
     )}

--- a/timeseries/src/main/javascript/app/pages/BackfillCreate.js
+++ b/timeseries/src/main/javascript/app/pages/BackfillCreate.js
@@ -151,7 +151,7 @@ class BackfillCreate extends React.Component<Props> {
       body: JSON.stringify({
         name: name,
         description: description || "",
-        jobs: jobs.join(","),
+        jobs: jobs,
         priority: priority,
         startDate: start.toISOString(),
         endDate: end.toISOString()

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/Internal.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/Internal.scala
@@ -39,7 +39,7 @@ private[timeseries] object BackfillCreate {
 private[timeseries] case class BackfillCreate(
   name: String,
   description: String,
-  jobs: String,
+  jobs: List[String],
   startDate: Instant,
   endDate: Instant,
   priority: Int


### PR DESCRIPTION
The backfilled jobs list is now sent as a real list instead of a string with comma separated ids