### PR TITLE
Add longRunningId to SchedulingContext

### DIFF
--- a/core/src/it/scala/com/criteo/cuttle/TestScheduling.scala
+++ b/core/src/it/scala/com/criteo/cuttle/TestScheduling.scala
@@ -18,6 +18,7 @@ trait TestScheduling {
     val toJson: Json = Json.Null
     val log: ConnectionIO[String] = "id".pure[ConnectionIO]
     def compareTo(other: SchedulingContext) = 0
+    override def longRunningId(): String = toString
   }
 
   case class TestScheduling(config: Unit = ()) extends Scheduling {

--- a/core/src/main/scala/com/criteo/cuttle/Scheduling.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Scheduling.scala
@@ -56,6 +56,9 @@ trait SchedulingContext {
   /** Compare to another context. In the current design only context of the same types will be
     * compared to each other because a workflow/project is defined for a single [[Scheduling]] type. */
   def compareTo(other: SchedulingContext): Int
+
+  /** An id to identify a context after a reboot of the application */
+  def longRunningId(): String
 }
 
 /** Utilities for [[SchedulingContext]] */

--- a/core/src/test/scala/com/criteo/cuttle/TestScheduling.scala
+++ b/core/src/test/scala/com/criteo/cuttle/TestScheduling.scala
@@ -20,6 +20,7 @@ trait TestScheduling {
     val toJson: Json = Json.Null
     val log: ConnectionIO[String] = "id".pure[ConnectionIO]
     def compareTo(other: SchedulingContext) = 0
+    override def longRunningId(): String = toString
   }
 
   case class TestScheduling(config: Unit = ()) extends Scheduling {

--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronModel.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronModel.scala
@@ -134,6 +134,8 @@ case class CronContext(instant: Instant)(retryNum: Int) extends SchedulingContex
   }
 
   override def asJson: Json = CronContext.encoder(this)
+
+  override def longRunningId(): String = toString
 }
 
 case object CronContext {

--- a/examples/src/main/scala/com/criteo/cuttle/examples/HelloCustomScheduling.scala
+++ b/examples/src/main/scala/com/criteo/cuttle/examples/HelloCustomScheduling.scala
@@ -48,6 +48,8 @@ object HelloCustomScheduling {
         case LoopContext(otherIteration) =>
           iteration - otherIteration
       }
+
+      override def longRunningId(): String = toString
     }
 
     // This our scheduling definition and configuration. For example

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -265,6 +265,10 @@ case class TimeSeriesContext(start: Instant,
         thisBackfillPriority.compareTo(otherBackfillPriority)
       }
   }
+
+  override def longRunningId(): String = {
+    (start, end, backfill).toString
+  }
 }
 
 object TimeSeriesContext {


### PR DESCRIPTION
Add a method to get an id to identify a context across
reboots of the application.