### PR TITLE
[timeseries] Execution Streams > handle non standard messages in view

### DIFF
--- a/timeseries/src/main/javascript/app/pages/Execution.js
+++ b/timeseries/src/main/javascript/app/pages/Execution.js
@@ -191,7 +191,12 @@ class Execution extends React.Component<Props, State> {
             level,
             message
           });
-        }
+        } else
+          lines.push({
+            timestamp: "",
+            level: "ERROR",
+            message: line
+          });
       });
       const streamsHead = this.shouldOverwriteStreams ? [] : this.state.streams;
       this.shouldOverwriteStreams = false;


### PR DESCRIPTION
Messages without Timestamp / level like `--- CONTENT TRUNCATED AT xxx` are not displayed otherwise