### PR TITLE
Executor log execution errors

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -698,8 +698,10 @@ class Executor[S <: Scheduling](val platforms: Seq[ExecutionPlatform],
           case Failure(e) =>
             val stacktrace = new StringWriter()
             e.printStackTrace(new PrintWriter(stacktrace))
+            val stacktraceString = stacktrace.toString
             execution.streams.error(s"Execution failed:")
-            execution.streams.error(stacktrace.toString)
+            execution.streams.error(stacktraceString)
+            logger.warn(s"Execution ${execution.id} failed: $e\n${stacktraceString}")
             atomic {
               implicit tx =>
                 updateFinishedExecutionCounters(execution, "failure")

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/Internal.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/Internal.scala
@@ -6,7 +6,6 @@ import cats.syntax.either._
 import io.circe._
 import io.circe.generic.semiauto.deriveDecoder
 import io.circe.java8.time._
-import io.circe.syntax._
 
 import com.criteo.cuttle._
 import com.criteo.cuttle.timeseries.intervals.Interval


### PR DESCRIPTION
As streams can be truncated, there are debug cases where we want to get error anyway