### PR TITLE
Log execution error stream as application warning

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Executor.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Executor.scala
@@ -784,6 +784,10 @@ class Executor[S <: Scheduling](val platforms: Seq[ExecutionPlatform],
                   val nextExecutionId = utils.randomUUID
 
                   val streams = new ExecutionStreams {
+                    override def error(str: CharSequence = ""): Unit = {
+                      super.error(str)
+                      logger.warn(s"Execution error: $nextExecutionId > $str")
+                    }
                     def writeln(str: CharSequence) =
                       ExecutionStreams.writeln(nextExecutionId, str)
                   }


### PR DESCRIPTION
As logs can be truncated over a maximum length