### PR TITLE
Bulk dependencies update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ val writeClasspath = taskKey[File]("Write the project classpath to a file.")
 val VERSION = "0.9.12"
 
 lazy val catsCore = "1.5.0"
-lazy val circe = "0.11.1"
-lazy val doobie = "0.7.0"
+lazy val circe = "0.10.1"
+lazy val doobie = "0.6.0"
 lazy val lolhttp = "0.12.0"
 
 lazy val commonSettings = Seq(
@@ -260,7 +260,7 @@ lazy val cron =
     .settings(commonSettings: _*)
     .settings(Defaults.itSettings: _*)
     .settings(
-      libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.5.0"
+      libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.4.5"
     )
     .settings(
       fork in Test := true

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ val writeClasspath = taskKey[File]("Write the project classpath to a file.")
 val VERSION = "0.9.12"
 
 lazy val catsCore = "1.5.0"
-lazy val circe = "0.10.1"
-lazy val doobie = "0.6.0"
+lazy val circe = "0.11.1"
+lazy val doobie = "0.7.0"
 lazy val lolhttp = "0.12.0"
 
 lazy val commonSettings = Seq(
@@ -168,7 +168,7 @@ lazy val localdb = {
     .settings(
       publishArtifact := false,
       libraryDependencies ++= Seq(
-        "ch.vorburger.mariaDB4j" % "mariaDB4j" % "2.3.0"
+        "ch.vorburger.mariaDB4j" % "mariaDB4j" % "2.4.0"
       )
     )
 }
@@ -188,11 +188,11 @@ lazy val cuttle =
         .map(module => "io.circe" %% s"circe-$module" % circe),
       libraryDependencies ++= Seq(
         "de.sciss" %% "fingertree" % "1.5.2",
-        "org.scala-stm" %% "scala-stm" % "0.8",
+        "org.scala-stm" %% "scala-stm" % "0.9.1",
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
         "org.typelevel" %% "cats-core" % catsCore,
         "codes.reactive" %% "scala-time" % "0.4.2",
-        "com.zaxxer" % "nuprocess" % "1.1.0",
+        "com.zaxxer" % "nuprocess" % "1.1.3",
         "mysql" % "mysql-connector-java" % "6.0.6"
       ),
       libraryDependencies ++= Seq(
@@ -200,7 +200,7 @@ lazy val cuttle =
         "org.tpolecat" %% "doobie-hikari"
       ).map(_ % doobie),
       libraryDependencies ++= Seq(
-        "org.scalatest" %% "scalatest" % "3.0.1",
+        "org.scalatest" %% "scalatest" % "3.0.8",
         "org.mockito" % "mockito-all" % "1.10.19",
         "org.tpolecat" %% "doobie-scalatest" % doobie
       ).map(_ % "it,test")
@@ -211,7 +211,7 @@ lazy val timeseries =
     .settings(commonSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
-        "ch.vorburger.mariaDB4j" % "mariaDB4j" % "2.3.0" % "test"
+        "ch.vorburger.mariaDB4j" % "mariaDB4j" % "2.4.0" % "test"
       )
     )
     .settings(
@@ -260,7 +260,7 @@ lazy val cron =
     .settings(commonSettings: _*)
     .settings(Defaults.itSettings: _*)
     .settings(
-      libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.4.5"
+      libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.5.0"
     )
     .settings(
       fork in Test := true
@@ -272,7 +272,7 @@ lazy val examples =
     .settings(commonSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
-        "ch.vorburger.mariaDB4j" % "mariaDB4j" % "2.3.0" % "test"
+        "ch.vorburger.mariaDB4j" % "mariaDB4j" % "2.4.0" % "test"
       )
     )
     .settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")


### PR DESCRIPTION
- Update mariaDB4j to 2.4.0 #399
- Update sbt-unidoc to 0.4.2 #403
- Update cron4s-core to 0.5.0 #405
- Update sbt-pgp to 1.1.2 #406
- Update nuprocess to 1.1.3 #407
- Update fingertree to 1.5.4 #408
- Update circe to 0.11.1 #409
- Update scala-stm to 0.9.1 #411
- Update scalatest to 3.0.8 #412
- Update doobie to 0.7.0 #413
- Update sbt-sonatype to 2.5 #415