### PR TITLE
Fix job duration display

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ To run the example application, checkout the repository, launch the [sbt](http:/
 
 The library is cross-built for __Scala 2.11__ and __Scala 2.12__.
 
-The core module to use is `"com.criteo.cuttle" %% "cuttle" % "0.9.16"`.
+The core module to use is `"com.criteo.cuttle" %% "cuttle" % "0.9.17"`.
 
 You also need to fetch one __Scheduler__ implementation:
-- __TimeSeries__: `"com.criteo.cuttle" %% "timeseries" % "0.9.16""`.
-- __Cron__: `"com.criteo.cuttle" %% "cron" % "0.9.16""`.
+- __TimeSeries__: `"com.criteo.cuttle" %% "timeseries" % "0.9.17""`.
+- __Cron__: `"com.criteo.cuttle" %% "cron" % "0.9.17""`.
 
 # License
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val devMode = settingKey[Boolean]("Some build optimization are applied in devMode.")
 val writeClasspath = taskKey[File]("Write the project classpath to a file.")
 
-val VERSION = "0.9.16"
+val VERSION = "0.9.17"
 
 lazy val catsCore = "1.6.1"
 lazy val circe = "0.11.1"

--- a/timeseries/src/main/javascript/app/pages/Execution.js
+++ b/timeseries/src/main/javascript/app/pages/Execution.js
@@ -284,23 +284,22 @@ class Execution extends React.Component<Props, State> {
                 ? [
                     <dt key="duration">Duration:</dt>,
                     <dd key="duration_">
-                      {data.endTime ? (
-                        [
-                          moment
-                            .utc(
-                              moment(data.endTime).diff(moment(data.startTime))
-                            )
-                            .format("HH:mm:ss"),
-                          <ProgressBar
+                      {data.endTime ?  (
+                        (() => {
+                          const duration = moment(data.endTime).diff(moment(data.startTime))
+                          const timePart = moment
+                            .utc(duration)
+                            .format("HH:mm:ss")
+                          const dayPart = moment.duration(duration).days()
+                          const durationMsg = (dayPart === 0) ? timePart : `${dayPart} days ${timePart}`
+                          const progressBar = <ProgressBar
                             key="progressBar"
-                            totalTimeSeconds={
-                              moment(data.endTime).diff(
-                                moment(data.startTime)
-                              ) / 1000
-                            }
+                            totalTimeSeconds = {duration / 1000}
                             waitingTimeSeconds={data.waitingSeconds}
                           />
-                        ]
+                          return [durationMsg, progressBar]
+                        }
+                        )()
                       ) : (
                         <Clock time={data.startTime} humanize={false} />
                       )}


### PR DESCRIPTION
Job execution duration display cannot go above 24h.
The moment.format function can only generate days between 1 and 31.
For durations > 24h, we display days explicitly