### PR TITLE
Fix timeseries workflow validation (start-dates)

### DIFF
--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -1168,8 +1168,8 @@ object TimeSeriesUtils {
     val errors = collection.mutable.ListBuffer(Workflow.validate(workflow): _*)
 
     workflow.edges.map {
-      case (childJob, parentJob, _) =>
-        if (childJob.scheduling.start.isBefore(parentJob.scheduling.start)) {
+      case (childJob, parentJob, timeSeriesDependency) =>
+        if (childJob.scheduling.start.isBefore(parentJob.scheduling.start.minus(timeSeriesDependency.offsetLow))) {
           errors += s"Job [${childJob.id}] starts at [${childJob.scheduling.start.toString}] " +
             s"before his parent [${parentJob.id}] at [${parentJob.scheduling.start.toString}]"
         }

--- a/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesUtilsSpec.scala
+++ b/timeseries/src/test/scala/com/criteo/cuttle/timeseries/TimeSeriesUtilsSpec.scala
@@ -1,12 +1,11 @@
 package com.criteo.cuttle.timeseries.intervals
 
-import org.scalatest.FunSuite
-import de.sciss.fingertree.FingerTree
+import java.time.Duration
 
 import com.criteo.cuttle.timeseries._
-import com.criteo.cuttle.timeseries.JobState.{Done, Todo}
-import com.criteo.cuttle.timeseries.TimeSeriesUtils.State
 import com.criteo.cuttle.{Job, TestScheduling}
+import de.sciss.fingertree.FingerTree
+import org.scalatest.FunSuite
 
 class TimeSeriesUtilsSpec extends FunSuite with TestScheduling {
   private val scheduling: TimeSeries = hourly(date"2017-03-25T02:00:00Z")
@@ -60,5 +59,15 @@ class TimeSeriesUtilsSpec extends FunSuite with TestScheduling {
             )
         }
     }
+  }
+
+  test("validate workflow") {
+    val j1 = jobAsWorkflow(Job("j1", hourly(date"2019-10-10T01:00:00Z"))(completed))
+    val j2 = jobAsWorkflow(Job("j2", hourly(date"2019-10-10T02:00:00Z"))(completed))
+    println(TimeSeriesUtils.validate(j2.dependsOn(j1)))
+    assert(TimeSeriesUtils.validate(j2.dependsOn(j1)).isRight)
+    assert(TimeSeriesUtils.validate(j1.dependsOn(j2)).isLeft)
+    val timeOffset = TimeSeriesDependency(Duration.ofHours(1), Duration.ofHours(1))
+    assert(TimeSeriesUtils.validate(j1.dependsOn((j2, timeOffset))).isRight)
   }
 }


### PR DESCRIPTION
The validation didn't took into account the TimeSeriesDependency offset.
So it was possible to define a graph with job A depending on several
hours of B but both with the same start date. Hence the first executions
of A could not be scheduled.