### PR TITLE
Fix UI for Backfills when screen has many jobs.

### DIFF
--- a/timeseries/src/main/javascript/app/components/FancyTable.js
+++ b/timeseries/src/main/javascript/app/components/FancyTable.js
@@ -17,6 +17,7 @@ const FancyTableComponent = ({ classes, key, children }: Props) => (
 
 const styles = {
   definitions: {
+    flex: "none",
     overflow: "auto",
     margin: "0",
     display: "flex",


### PR DESCRIPTION
When the list of jobs is too big, the header of the details
of the backfill was too small to show the contents.