### PR TITLE
Expose Execution.cancel() more properly

### DIFF
--- a/cron/src/main/scala/com/criteo/cuttle/cron/CronScheduler.scala
+++ b/cron/src/main/scala/com/criteo/cuttle/cron/CronScheduler.scala
@@ -87,7 +87,7 @@ case class CronScheduler(logger: Logger) extends Scheduler[CronScheduling] {
         logger.debug(s"Canceling ${executions.size} executions")
         executions.foreach { execution =>
           execution.streams.debug(s"Job has been paused by user ${user.userId}")
-          execution.cancel()
+          execution.userCancel()
         }
     }
   }

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -1070,7 +1070,7 @@ private[timeseries] case class TimeSeriesApp(project: CuttleProject,
         }
         val failingExecutions = executor.allFailingExecutions.filter(filterOp)
         val executions = runningExecutions ++ failingExecutions
-        executions.foreach(_.cancel())
+        executions.foreach(_.userCancel())
         (
           executions.length,
           JobSuccessForced(Instant.now(), user, jobId, startDate, endDate)

--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesScheduler.scala
@@ -695,7 +695,7 @@ case class TimeSeriesScheduler(logger: Logger,
     logger.debug(s"we will cancel ${executionsToCancel.size} executions")
     executionsToCancel.toList.sortBy(_.context).reverse.foreach { execution =>
       execution.streams.debug(s"Job has been paused by user ${user.userId}")
-      execution.cancel()
+      execution.userCancel()
     }
   }
 


### PR DESCRIPTION
- The current `cancel` function requiring a `User` is made internal to cuttle and renamed `userCancel`
- Add a new `cancel` function that takes no parameter, that does the same but with no logging