### PR TITLE
[build] Fix 'params' cannot be negated in scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val commonSettings = Seq(
     "-Ywarn-unused-import",
     "-Ypartial-unification"
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 12)) => Seq("-Ywarn-unused:-params")
+    case Some((2, 12)) => Seq("-Ywarn-unused:-explicits,-implicits")
     case _             => Nil
   }),
   devMode := Option(System.getProperty("devMode")).isDefined,


### PR DESCRIPTION
As per https://github.com/scala/bug/issues/10572
change
-Ywarn-unused:-params
into
-Ywarn-unused:-explicits,-implicits