### PR TITLE
Fix time series executions view not updating

### DIFF
--- a/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
+++ b/timeseries/src/main/scala/com/criteo/cuttle/timeseries/TimeSeriesApp.scala
@@ -728,14 +728,14 @@ private[timeseries] case class TimeSeriesApp(project: CuttleProject,
         runningDependencies ++ failingDependencies ++ remainingDependenciesDeps.toSeq
       }
 
-      val watchedState = snapshotWatchedState()
+      val watchedState = IO(snapshotWatchedState())
       if (request.headers.get(h"Accept").contains(h"text/event-stream")) {
         sse(
-          IO { Some(watchedState) },
+          watchedState.map(Some(_)),
           (s: WatchedState) => getExecutions(s)
         )
       } else {
-        getExecutions(watchedState).map(Ok(_))
+        watchedState.flatMap(getExecutions).map(Ok(_))
       }
 
     case GET at url"/api/timeseries/calendar/focus?start=$start&end=$end&jobs=$jobs" =>


### PR DESCRIPTION
The time series executions view (when clicking on a specific interval of a specific job in the calendar focus view) queries an url to get the list of executions, and is supposed to use server sent events to auto refresh that list.
However that url would simply serve the first snapshot and never refresh it, due to the snapshot being put in a pure IO after it has been computed.
We just fix that by putting the actual computation of the snapshot in an IO, which will refresh the server sent events properly.