### PR TITLE
Check that the server is not readonly in DB health check

### DIFF
--- a/core/src/main/scala/com/criteo/cuttle/Database.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Database.scala
@@ -397,7 +397,7 @@ private[cuttle] case class Queries(logger: Logger) {
   }
 
   val healthCheck: ConnectionIO[Boolean] =
-    sql"""select 1 from dual"""
+    sql"""SELECT @@global.read_only IS FALSE"""
       .query[Boolean]
       .unique
 }


### PR DESCRIPTION
This fixes an issue where the DB server becomes readonly while the application is running, and the application silently fails when trying to write to it (at least in the case of Cuttle Cron)