### PR TITLE
Revert "Revert "Use mariadb driver instead of mysql (#537)""

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -225,7 +225,7 @@ lazy val cuttle =
         "org.typelevel" %% "cats-core" % catsCore,
         "codes.reactive" %% "scala-time" % "0.4.2",
         "com.zaxxer" % "nuprocess" % "1.1.3",
-        "mysql" % "mysql-connector-java" % "8.0.17"
+        "org.mariadb.jdbc" % "mariadb-java-client" % "2.7.0"
       ),
       libraryDependencies ++= Seq(
         "org.tpolecat" %% "doobie-core",

--- a/core/src/main/scala/com/criteo/cuttle/Database.scala
+++ b/core/src/main/scala/com/criteo/cuttle/Database.scala
@@ -186,14 +186,14 @@ object Database {
     import com.criteo.cuttle.ThreadPools.Implicits.doobieContextShift
 
     val locationString = dbConfig.locations.map(dbLocation => s"${dbLocation.host}:${dbLocation.port}").mkString(",")
-    val jdbcString = s"jdbc:mysql://$locationString/${dbConfig.database}" +
+    val jdbcString = s"jdbc:mariadb://$locationString/${dbConfig.database}" +
       "?serverTimezone=UTC&useSSL=false&allowMultiQueries=true&failOverReadOnly=false&rewriteBatchedStatements=true"
 
     for {
       connectThreadPool <- ThreadPools.doobieConnectThreadPoolResource
       transactThreadPool <- ThreadPools.doobieTransactThreadPoolResource
       transactor <- HikariTransactor.newHikariTransactor[IO](
-        "com.mysql.cj.jdbc.Driver",
+        "org.mariadb.jdbc.Driver",
         jdbcString,
         dbConfig.username,
         dbConfig.password,


### PR DESCRIPTION
Reverts criteo/cuttle#581 for following release.