### PR TITLE
Frontend fixes

### DIFF
--- a/frontend/javascript/cron/pages/Dags.js
+++ b/frontend/javascript/cron/pages/Dags.js
@@ -140,13 +140,13 @@ const sortFunction: Sort => DagsOrder = (sort: Sort) => (
   const userOrder = (a: DisplayedDag, b: DisplayedDag) =>
     a.pausedUser.localeCompare(b.pausedUser);
   const nextInstantOrder = (a: DisplayedDag, b: DisplayedDag) =>
-    new Date(a.nextInstant)
-      .toISOString()
-      .localeCompare(new Date(b.nextInstant).toISOString());
+    formatInstantForCompare(a.nextInstant).localeCompare(
+      formatInstantForCompare(b.nextInstant)
+    );
   const pausedDateOrder = (a: DisplayedDag, b: DisplayedDag) =>
-    new Date(a.pausedDate)
-      .toISOString()
-      .localeCompare(new Date(b.pausedDate).toISOString());
+    formatInstantForCompare(a.pausedDate).localeCompare(
+      formatInstantForCompare(b.pausedDate)
+    );
   const sortFn = (sort: Sort) => {
     switch (sort.column) {
       case "id":
@@ -167,6 +167,10 @@ const sortFunction: Sort => DagsOrder = (sort: Sort) => (
   };
 
   return sort.order === "desc" ? -sortFn(sort)(a, b) : sortFn(sort)(a, b);
+};
+
+const formatInstantForCompare = (str: string) => {
+  return (str && new Date(str).toISOString()) || str;
 };
 
 const processResponse = (response: Response) => {

--- a/frontend/javascript/timeseries/pages/Jobs.js
+++ b/frontend/javascript/timeseries/pages/Jobs.js
@@ -307,7 +307,7 @@ class JobsComp extends React.Component<Props, State> {
       }
     };
 
-    const jobs = selectedJobs
+    const jobs = selectedJobs;
     const persist = this.setState.bind(this);
     const pause = jobAction("pause", jobs, persist);
     const resume = jobAction("resume", jobs, persist);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ const common = {
   output: {
     filename: "[name].js",
     path: outputPath,
-    publicPath: `/public/${project}`
+    publicPath: `/public/${project}/`
   },
 
   devtool: "sourcemap",


### PR DESCRIPTION
*  Fix fonts not being loaded properly:
The path generated by webpack was missing a `/`, so it would try to load `/public/timeseriesFiraMono-[].ttf` instead of `/public/timeseries/FiraMono-[].ttf`
*  Fix Cron UI breaking when trying to sort on dates:
Absent dates would fail to parse as `new Date(<empty string>)` and break everything, so simply don't parse them

